### PR TITLE
Fix appearance

### DIFF
--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -472,6 +472,17 @@ export const useAppState = () => {
   const handleThemeChange = (newTheme: ThemeName) => {
     setTheme(newTheme);
     applyThemeToDocument(newTheme);
+    // Keep settings UI and persistence in sync when theme is changed from the status bar
+    setAppSettings((prev) => {
+      const next: AppSettings = {
+        ...prev,
+        appearance: { ...prev.appearance, theme: newTheme },
+      };
+      storeApi.saveAppSettings(next).catch((err) =>
+        console.error('Failed to save theme to app settings:', err)
+      );
+      return next;
+    });
   };
 
   // New unified settings change handler


### PR DESCRIPTION
## Fix theme desync between status bar and Settings

### Problem
- Changing the theme from the status bar (bottom right) updated the UI but not the unified settings.
- Opening Settings showed the previous theme.
- Saving any setting in Settings reverted the theme to the old value.

### Cause
Theme was updated in two places: `theme` state (and store key `'theme'`) and `appSettings.appearance.theme` (inside `'appSettings'`). The status bar only updated the former, so Settings kept showing and persisting the old value.

### Solution
In `handleThemeChange` (useAppState.ts), when the theme is changed from the status bar we now:
1. Update `appSettings.appearance.theme` with the new value.
2. Call `storeApi.saveAppSettings()` so the unified settings and store stay in sync.

Result: the theme selected in the status bar is reflected in Settings and is not reverted when saving other settings.
