### PR TITLE
Fix images overflowing parent container in HTML export

### DIFF
--- a/src/utils/__tests__/exportStyles.test.ts
+++ b/src/utils/__tests__/exportStyles.test.ts
@@ -53,6 +53,14 @@ describe('generateExportCSS', () => {
     expect(css).toContain(colors.linkColor);
     expect(css).toContain('font-family');
   });
+
+  it('constrains images to fit within parent element', () => {
+    const colors = getExportThemeColors(false);
+    const css = generateExportCSS(colors);
+    expect(css).toContain('img');
+    expect(css).toContain('max-width: 100%');
+    expect(css).toContain('height: auto');
+  });
 });
 
 describe('buildExportHTML', () => {

--- a/src/utils/exportStyles.ts
+++ b/src/utils/exportStyles.ts
@@ -147,6 +147,11 @@ export function generateExportCSS(colors: ExportThemeColors): string {
             text-decoration: underline;
         }
 
+        img {
+            max-width: 100%;
+            height: auto;
+        }
+
         .hljs {
             background: ${colors.codeBackground} !important;
         }`;


### PR DESCRIPTION
## Summary
- Add `max-width: 100%; height: auto` CSS rule for images in exported HTML to prevent overflow from parent
container
- Images smaller than the parent element retain their original size

## Test plan
- [x] Added unit test to verify `generateExportCSS` includes image constraint rules
- [x] Export a document containing a large image and confirm it fits within the page width
- [x] Export a document containing a small image and confirm it stays at its original size