### PR TITLE
Fixed a bug with the shortcut keys for replacement

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -72,6 +72,7 @@ const MarkdownEditor: React.FC<EditorProps> = ({
   const { t } = useTranslation();
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchAllTabsDefault, setSearchAllTabsDefault] = useState(false);
+  const [showReplaceDefault, setShowReplaceDefault] = useState(false);
   const [tableConversionDialog, setTableConversionDialog] = useState<{
     open: boolean;
     markdownTable: string;
@@ -354,16 +355,19 @@ const MarkdownEditor: React.FC<EditorProps> = ({
       if (monaco) {
         editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {
           setSearchAllTabsDefault(false);
+          setShowReplaceDefault(false);
           setSearchOpen(true);
         });
 
         editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyH, () => {
           setSearchAllTabsDefault(false);
+          setShowReplaceDefault(true);
           setSearchOpen(true);
         });
 
         editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyF, () => {
           setSearchAllTabsDefault(true);
+          setShowReplaceDefault(false);
           setSearchOpen(true);
         });
 
@@ -513,6 +517,7 @@ const MarkdownEditor: React.FC<EditorProps> = ({
           activeTabId={activeTabId}
           onTabSwitch={onTabSwitch}
           searchAllTabsDefault={searchAllTabsDefault}
+          showReplaceDefault={showReplaceDefault}
         />
         {fileNotFound ? (
           <Box

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -665,6 +665,30 @@ const HelpDialog: React.FC<HelpProps> = ({ open, onClose }) => {
       </List>
 
       <Typography variant="h6" gutterBottom sx={{ mt: 3 }}>
+        {t('help.keyboardShortcuts.categories.editing')}
+      </Typography>
+      <List>
+        <ListItem>
+          <ListItemText
+            primary={getShortcutDisplay('F')}
+            secondary={t('help.keyboardShortcuts.shortcuts.search')}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary={getShortcutDisplay('F', true)}
+            secondary={t('help.keyboardShortcuts.shortcuts.searchAllTabs')}
+          />
+        </ListItem>
+        <ListItem>
+          <ListItemText
+            primary={getShortcutDisplay('H')}
+            secondary={t('help.keyboardShortcuts.shortcuts.replace')}
+          />
+        </ListItem>
+      </List>
+
+      <Typography variant="h6" gutterBottom sx={{ mt: 3 }}>
         {t('help.keyboardShortcuts.categories.view')}
       </Typography>
       <List>

--- a/src/components/SearchReplacePanel.tsx
+++ b/src/components/SearchReplacePanel.tsx
@@ -40,6 +40,7 @@ interface SearchReplacePanelProps {
   activeTabId?: string | null;
   onTabSwitch?: (tabId: string) => void;
   searchAllTabsDefault?: boolean;
+  showReplaceDefault?: boolean;
 }
 
 const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
@@ -51,6 +52,7 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
   activeTabId,
   onTabSwitch,
   searchAllTabsDefault = false,
+  showReplaceDefault = false,
 }) => {
   const { t } = useTranslation();
   const [searchText, setSearchText] = useState('');
@@ -69,12 +71,13 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
   const decorationIdsRef = useRef<string[]>([]);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Sync searchAllTabs with searchAllTabsDefault when panel opens
+  // Sync searchAllTabs and showReplace with defaults when panel opens
   useEffect(() => {
     if (open) {
       setSearchAllTabs(searchAllTabsDefault);
+      setShowReplace(showReplaceDefault);
     }
-  }, [open, searchAllTabsDefault]);
+  }, [open, searchAllTabsDefault, showReplaceDefault]);
 
   // Focus search input when panel opens
   useEffect(() => {

--- a/src/components/__tests__/Editor.test.tsx
+++ b/src/components/__tests__/Editor.test.tsx
@@ -20,12 +20,14 @@ vi.mock('../SearchReplacePanel', () => ({
   default: (props: {
     open: boolean;
     searchAllTabsDefault?: boolean;
+    showReplaceDefault?: boolean;
     onClose: () => void;
   }) =>
     props.open ? (
       <div
         data-testid="search-panel"
         data-all-tabs={String(!!props.searchAllTabsDefault)}
+        data-show-replace={String(!!props.showReplaceDefault)}
       >
         <button data-testid="close-search" onClick={props.onClose}>
           Close
@@ -334,6 +336,47 @@ describe('MarkdownEditor', () => {
 
       expect(screen.getByTestId('search-panel')).toBeInTheDocument();
       expect(screen.getByTestId('search-panel').dataset.allTabs).toBe('true');
+
+      delete (window as unknown as Record<string, unknown>).monaco;
+    });
+
+    // T-ED-13b: Ctrl+H opens search in replace mode
+    it('T-ED-13b: Ctrl+H opens search in replace mode', () => {
+      const KeyMod = { CtrlCmd: 2048, Shift: 1024 };
+      const KeyCode = { KeyF: 36, KeyH: 38, KeyV: 52 };
+      (window as unknown as Record<string, unknown>).monaco = { KeyMod, KeyCode };
+
+      render(<MarkdownEditor {...defaultProps()} />);
+      const mockEditor = createMockMonacoEditor();
+      capturedOnMount!(mockEditor);
+
+      // Execute Ctrl+H handler (second addCommand call)
+      const ctrlHHandler = (mockEditor.addCommand as ReturnType<typeof vi.fn>).mock.calls[1][1];
+      act(() => { ctrlHHandler(); });
+
+      expect(screen.getByTestId('search-panel')).toBeInTheDocument();
+      expect(screen.getByTestId('search-panel').dataset.showReplace).toBe('true');
+      expect(screen.getByTestId('search-panel').dataset.allTabs).toBe('false');
+
+      delete (window as unknown as Record<string, unknown>).monaco;
+    });
+
+    // T-ED-13c: Ctrl+F opens search without replace mode
+    it('T-ED-13c: Ctrl+F opens search without replace mode', () => {
+      const KeyMod = { CtrlCmd: 2048, Shift: 1024 };
+      const KeyCode = { KeyF: 36, KeyH: 38, KeyV: 52 };
+      (window as unknown as Record<string, unknown>).monaco = { KeyMod, KeyCode };
+
+      render(<MarkdownEditor {...defaultProps()} />);
+      const mockEditor = createMockMonacoEditor();
+      capturedOnMount!(mockEditor);
+
+      // Execute Ctrl+F handler (first addCommand call)
+      const ctrlFHandler = (mockEditor.addCommand as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      act(() => { ctrlFHandler(); });
+
+      expect(screen.getByTestId('search-panel')).toBeInTheDocument();
+      expect(screen.getByTestId('search-panel').dataset.showReplace).toBe('false');
 
       delete (window as unknown as Record<string, unknown>).monaco;
     });

--- a/src/components/__tests__/SearchReplacePanel.test.tsx
+++ b/src/components/__tests__/SearchReplacePanel.test.tsx
@@ -398,6 +398,42 @@ describe('SearchReplacePanel', () => {
     expect(editor.setSelection).toHaveBeenCalled();
   });
 
+  // T-SR-12b: showReplaceDefault=true opens panel with replace row visible
+  it('T-SR-12b: showReplaceDefault=true opens panel with replace row visible', () => {
+    const editor = createMockEditor('hello world');
+    const editorRef = { current: editor } as React.RefObject<never>;
+
+    render(
+      <SearchReplacePanel
+        editorRef={editorRef}
+        open={true}
+        onClose={vi.fn()}
+        onChange={vi.fn()}
+        showReplaceDefault={true}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText('Replace')).toBeInTheDocument();
+  });
+
+  // T-SR-12c: showReplaceDefault=false (default) opens panel without replace row
+  it('T-SR-12c: showReplaceDefault=false opens panel without replace row', () => {
+    const editor = createMockEditor('hello world');
+    const editorRef = { current: editor } as React.RefObject<never>;
+
+    render(
+      <SearchReplacePanel
+        editorRef={editorRef}
+        open={true}
+        onClose={vi.fn()}
+        onChange={vi.fn()}
+        showReplaceDefault={false}
+      />,
+    );
+
+    expect(screen.queryByPlaceholderText('Replace')).not.toBeInTheDocument();
+  });
+
   // T-SR-12: toggling checkbox switches between single and cross-tab mode
   it('T-SR-12: toggling checkbox switches between single and cross-tab search', () => {
     const editor = createMockEditor('hello world\ngoodbye world');

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -191,7 +191,10 @@
         "zoomOut": "تصغير",
         "resetZoom": "إعادة تعيين التكبير",
         "toggleExplorer": "تبديل المستكشف",
-        "toggleOutline": "تبديل المخطط"
+        "toggleOutline": "تبديل المخطط",
+        "search": "بحث",
+        "searchAllTabs": "البحث في جميع علامات التبويب",
+        "replace": "بحث واستبدال"
       }
     },
     "tutorials": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -191,7 +191,10 @@
         "zoomOut": "Verkleinern",
         "resetZoom": "Zoom zurücksetzen",
         "toggleExplorer": "Explorer umschalten",
-        "toggleOutline": "Gliederung umschalten"
+        "toggleOutline": "Gliederung umschalten",
+        "search": "Suchen",
+        "searchAllTabs": "Alle Tabs durchsuchen",
+        "replace": "Suchen und Ersetzen"
       }
     },
     "tutorials": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -191,7 +191,10 @@
         "zoomOut": "Zoom Out",
         "resetZoom": "Reset Zoom",
         "toggleExplorer": "Toggle Explorer",
-        "toggleOutline": "Toggle Outline"
+        "toggleOutline": "Toggle Outline",
+        "search": "Search",
+        "searchAllTabs": "Search All Tabs",
+        "replace": "Search and Replace"
       }
     },
     "tutorials": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -191,7 +191,10 @@
         "zoomOut": "Alejar",
         "resetZoom": "Restablecer zoom",
         "toggleExplorer": "Alternar explorador",
-        "toggleOutline": "Alternar esquema"
+        "toggleOutline": "Alternar esquema",
+        "search": "Buscar",
+        "searchAllTabs": "Buscar en todas las pestañas",
+        "replace": "Buscar y reemplazar"
       }
     },
     "tutorials": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -191,7 +191,10 @@
         "zoomOut": "Zoom arrière",
         "resetZoom": "Réinitialiser le zoom",
         "toggleExplorer": "Basculer l'explorateur",
-        "toggleOutline": "Basculer le plan"
+        "toggleOutline": "Basculer le plan",
+        "search": "Rechercher",
+        "searchAllTabs": "Rechercher dans tous les onglets",
+        "replace": "Rechercher et remplacer"
       }
     },
     "tutorials": {

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -191,7 +191,10 @@
         "zoomOut": "ज़ूम आउट",
         "resetZoom": "ज़ूम रीसेट करें",
         "toggleExplorer": "एक्सप्लोरर टॉगल करें",
-        "toggleOutline": "रूपरेखा टॉगल करें"
+        "toggleOutline": "रूपरेखा टॉगल करें",
+        "search": "खोजें",
+        "searchAllTabs": "सभी टैब में खोजें",
+        "replace": "खोजें और बदलें"
       }
     },
     "tutorials": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -191,7 +191,10 @@
         "zoomOut": "Perkecil",
         "resetZoom": "Reset Zoom",
         "toggleExplorer": "Beralih Penjelajah",
-        "toggleOutline": "Beralih Kerangka"
+        "toggleOutline": "Beralih Kerangka",
+        "search": "Cari",
+        "searchAllTabs": "Cari di semua tab",
+        "replace": "Cari dan ganti"
       }
     },
     "tutorials": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -191,7 +191,10 @@
         "zoomOut": "ズームアウト",
         "resetZoom": "ズームリセット",
         "toggleExplorer": "エクスプローラーの切り替え",
-        "toggleOutline": "アウトラインの切り替え"
+        "toggleOutline": "アウトラインの切り替え",
+        "search": "検索",
+        "searchAllTabs": "全タブを検索",
+        "replace": "検索と置換"
       }
     },
     "tutorials": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -191,7 +191,10 @@
         "zoomOut": "축소",
         "resetZoom": "확대/축소 재설정",
         "toggleExplorer": "탐색기 전환",
-        "toggleOutline": "개요 전환"
+        "toggleOutline": "개요 전환",
+        "search": "검색",
+        "searchAllTabs": "모든 탭 검색",
+        "replace": "검색 및 바꾸기"
       }
     },
     "tutorials": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -191,7 +191,10 @@
         "zoomOut": "Diminuir zoom",
         "resetZoom": "Redefinir zoom",
         "toggleExplorer": "Alternar explorador",
-        "toggleOutline": "Alternar esboço"
+        "toggleOutline": "Alternar esboço",
+        "search": "Pesquisar",
+        "searchAllTabs": "Pesquisar em todas as abas",
+        "replace": "Pesquisar e substituir"
       }
     },
     "tutorials": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -191,7 +191,10 @@
         "zoomOut": "Уменьшить",
         "resetZoom": "Сбросить масштаб",
         "toggleExplorer": "Переключить проводник",
-        "toggleOutline": "Переключить структуру"
+        "toggleOutline": "Переключить структуру",
+        "search": "Поиск",
+        "searchAllTabs": "Поиск по всем вкладкам",
+        "replace": "Поиск и замена"
       }
     },
     "tutorials": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -191,7 +191,10 @@
         "zoomOut": "Thu nhỏ",
         "resetZoom": "Đặt lại zoom",
         "toggleExplorer": "Bật/tắt trình khám phá",
-        "toggleOutline": "Bật/tắt dàn ý"
+        "toggleOutline": "Bật/tắt dàn ý",
+        "search": "Tìm kiếm",
+        "searchAllTabs": "Tìm kiếm tất cả tab",
+        "replace": "Tìm kiếm và thay thế"
       }
     },
     "tutorials": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -191,7 +191,10 @@
         "zoomOut": "缩小",
         "resetZoom": "重置缩放",
         "toggleExplorer": "切换资源管理器",
-        "toggleOutline": "切换大纲"
+        "toggleOutline": "切换大纲",
+        "search": "搜索",
+        "searchAllTabs": "搜索所有标签页",
+        "replace": "搜索和替换"
       }
     },
     "tutorials": {

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -191,7 +191,10 @@
         "zoomOut": "縮小",
         "resetZoom": "重設縮放",
         "toggleExplorer": "切換檔案總管",
-        "toggleOutline": "切換大綱"
+        "toggleOutline": "切換大綱",
+        "search": "搜尋",
+        "searchAllTabs": "搜尋所有分頁",
+        "replace": "搜尋與取代"
       }
     },
     "tutorials": {


### PR DESCRIPTION
## Summary
- Fix a bug where `Ctrl/Cmd+H` opened the search panel in search mode instead of replace mode. The handler was identical to `Ctrl/Cmd+F`, with no mechanism to pass replace mode state
to `SearchReplacePanel`.
- Add a `showReplaceDefault` prop to `SearchReplacePanel` so the parent can control whether the panel opens in replace mode.
- Add search-related keyboard shortcuts (Search, Search All Tabs, Replace) to the Help keyboard shortcuts section under a new "Editing" category.

## Changes
- **Editor.tsx**: Add `showReplaceDefault` state; set it to `true` on `Ctrl+H`, `false` on `Ctrl+F` / `Ctrl+Shift+F`
- **SearchReplacePanel.tsx**: Accept `showReplaceDefault` prop and sync `showReplace` state when the panel opens
- **Help.tsx**: Add "Editing" category with search/replace shortcuts
- **locales/*.json**: Add translation keys for all 14 languages

## Test
- [x] T-ED-13b: Ctrl+H opens search panel with `showReplaceDefault=true`
- [x] T-ED-13c: Ctrl+F opens search panel with `showReplaceDefault=false`
- [x] T-SR-12b: Panel shows replace row when `showReplaceDefault=true`
- [x] T-SR-12c: Panel hides replace row when `showReplaceDefault=false`
- [x] All existing tests pass