### PR TITLE
Add tab rename via right-click context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,7 @@ function AppDesktop() {
     handleRenameRequest,
     handleRenameConfirm,
     handleRenameCancel,
+    handleTabRenameRequest,
 
     // Translation
     t,
@@ -435,6 +436,7 @@ function AppDesktop() {
           onFolderTreeRefresh={folderTreeRefreshTree}
           onFolderTreePanelClose={() => setFolderTreePanelOpen(false)}
           onRenameRequest={handleRenameRequest}
+          onTabRename={handleTabRenameRequest}
           onTabChange={handleTabChange}
           onTabClose={handleTabClose}
           onNewTab={handleNewTab}

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -57,6 +57,7 @@ interface AppContentProps {
   onFolderTreeRefresh: () => void;
   onFolderTreePanelClose: () => void;
   onRenameRequest?: (filePath: string) => void;
+  onTabRename?: (tabId: string) => void;
 
   // Handlers
   onTabChange: (tabId: string) => void;
@@ -103,6 +104,7 @@ const AppContent: React.FC<AppContentProps> = ({
   onFolderTreeRefresh,
   onFolderTreePanelClose,
   onRenameRequest,
+  onTabRename,
   onTabChange,
   onTabClose,
   onNewTab,
@@ -246,6 +248,7 @@ const AppContent: React.FC<AppContentProps> = ({
               onTabClose={onTabClose}
               onNewTab={onNewTab}
               onTabReorder={onTabReorder}
+              onTabRename={onTabRename}
               layout="vertical"
               embedded
             />
@@ -297,6 +300,7 @@ const AppContent: React.FC<AppContentProps> = ({
           onTabClose={onTabClose}
           onNewTab={onNewTab}
           onTabReorder={onTabReorder}
+          onTabRename={onTabRename}
           layout={tabLayout}
         />
       )}
@@ -327,6 +331,7 @@ const AppContent: React.FC<AppContentProps> = ({
             onTabClose={onTabClose}
             onNewTab={onNewTab}
             onTabReorder={onTabReorder}
+            onTabRename={onTabRename}
             layout={tabLayout}
           />
         )}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -10,8 +10,11 @@ import {
   ListItem,
   ListItemButton,
   Divider,
+  Menu,
+  MenuItem,
 } from '@mui/material';
 import { Close, Add } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
 import { Tab as TabType } from '../types/tab';
 import {
   DndContext,
@@ -42,6 +45,7 @@ interface TabBarProps {
   onTabClose: (tabId: string) => void;
   onNewTab: () => void;
   onTabReorder: (tabs: TabType[]) => void;
+  onTabRename?: (tabId: string) => void;
   layout?: 'horizontal' | 'vertical';
   embedded?: boolean;
 }
@@ -63,8 +67,9 @@ const SortableTab: React.FC<{
   isActive: boolean;
   onClose: (event: React.MouseEvent, tabId: string) => void;
   onClick: (tabId: string) => void;
+  onContextMenu?: (event: React.MouseEvent, tabId: string) => void;
   layout: 'horizontal' | 'vertical';
-}> = ({ tab, isActive, onClose, onClick, layout }) => {
+}> = ({ tab, isActive, onClose, onClick, onContextMenu, layout }) => {
   const {
     attributes,
     listeners,
@@ -105,6 +110,7 @@ const SortableTab: React.FC<{
         <ListItemButton
           selected={isActive}
           onClick={() => onClick(tab.id)}
+          onContextMenu={(e) => onContextMenu?.(e, tab.id)}
           sx={{
             py: 1,
             px: 2,
@@ -175,6 +181,7 @@ const SortableTab: React.FC<{
       style={style}
       value={tab.id}
       onClick={() => onClick(tab.id)}
+      onContextMenu={(e) => onContextMenu?.(e, tab.id)}
       label={
         <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', minWidth: 0 }}>
           <Box
@@ -258,15 +265,36 @@ const TabBar: React.FC<TabBarProps> = ({
   onTabClose,
   onNewTab,
   onTabReorder,
+  onTabRename,
   layout = 'horizontal',
   embedded = false,
 }) => {
+  const { t } = useTranslation();
   const sensors = useSensors(
     createThresholdPointerSensor(),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
+
+  // Context menu state
+  const [contextMenu, setContextMenu] = React.useState<{ mouseX: number; mouseY: number; tabId: string } | null>(null);
+
+  const handleContextMenu = useCallback((event: React.MouseEvent, tabId: string) => {
+    event.preventDefault();
+    setContextMenu({ mouseX: event.clientX, mouseY: event.clientY, tabId });
+  }, []);
+
+  const handleContextMenuClose = useCallback(() => {
+    setContextMenu(null);
+  }, []);
+
+  const handleRenameClick = useCallback(() => {
+    if (contextMenu && onTabRename) {
+      onTabRename(contextMenu.tabId);
+    }
+    setContextMenu(null);
+  }, [contextMenu, onTabRename]);
 
   const handleTabClick = (_event: React.SyntheticEvent, tabIndex: number) => {
     const tab = tabs[tabIndex];
@@ -339,6 +367,7 @@ const TabBar: React.FC<TabBarProps> = ({
                     isActive={tab.id === activeTabId}
                     onClose={handleTabClose}
                     onClick={onTabChange}
+                    onContextMenu={handleContextMenu}
                     layout="vertical"
                   />
                   {index < tabs.length - 1 && <Divider />}
@@ -347,6 +376,20 @@ const TabBar: React.FC<TabBarProps> = ({
             </List>
           </SortableContext>
         </DndContext>
+        {onTabRename && (
+          <Menu
+            open={contextMenu !== null}
+            onClose={handleContextMenuClose}
+            anchorReference="anchorPosition"
+            anchorPosition={
+              contextMenu !== null
+                ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+                : undefined
+            }
+          >
+            <MenuItem onClick={handleRenameClick}>{t('folderTree.rename')}</MenuItem>
+          </Menu>
+        )}
       </Box>
     );
   }
@@ -402,6 +445,7 @@ const TabBar: React.FC<TabBarProps> = ({
                   isActive={tab.id === activeTabId}
                   onClose={handleTabClose}
                   onClick={onTabChange}
+                  onContextMenu={handleContextMenu}
                   layout="horizontal"
                 />
               ))}
@@ -422,6 +466,20 @@ const TabBar: React.FC<TabBarProps> = ({
           </IconButton>
         </Tooltip>
       </Box>
+      {onTabRename && (
+        <Menu
+          open={contextMenu !== null}
+          onClose={handleContextMenuClose}
+          anchorReference="anchorPosition"
+          anchorPosition={
+            contextMenu !== null
+              ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+              : undefined
+          }
+        >
+          <MenuItem onClick={handleRenameClick}>{t('folderTree.rename')}</MenuItem>
+        </Menu>
+      )}
     </Box>
   );
 };

--- a/src/components/__tests__/TabBar.test.tsx
+++ b/src/components/__tests__/TabBar.test.tsx
@@ -3,6 +3,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import type { Tab as TabType } from '../../types/tab';
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
 // Mock dnd-kit to avoid complex DnD setup
 vi.mock('@dnd-kit/core', () => ({
   DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -222,5 +228,87 @@ describe('TabBar', () => {
     // The root Box should not have width: 280 when embedded
     const rootBox = container.firstElementChild as HTMLElement;
     expect(rootBox.style.width).not.toBe('280px');
+  });
+
+  // --- Context menu / Rename tests ---
+
+  // T-TB-15: right-click on horizontal tab shows context menu with Rename
+  it('T-TB-15: right-click on horizontal tab shows context menu', () => {
+    const onTabRename = vi.fn();
+    render(
+      <TabBar
+        {...defaultProps()}
+        onTabRename={asMock<(tabId: string) => void>(onTabRename)}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText('File1.md'));
+    expect(screen.getByText('folderTree.rename')).toBeInTheDocument();
+  });
+
+  // T-TB-16: clicking Rename in context menu calls onTabRename with correct ID
+  it('T-TB-16: Rename menu item calls onTabRename with correct tab ID', () => {
+    const onTabRename = vi.fn();
+    render(
+      <TabBar
+        {...defaultProps()}
+        onTabRename={asMock<(tabId: string) => void>(onTabRename)}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText('File2.md'));
+    fireEvent.click(screen.getByText('folderTree.rename'));
+    expect(onTabRename).toHaveBeenCalledWith('tab2');
+  });
+
+  // T-TB-17: clicking Rename calls handler and menu item becomes hidden
+  it('T-TB-17: Rename click triggers handler (menu will close via state)', () => {
+    const onTabRename = vi.fn();
+    render(
+      <TabBar
+        {...defaultProps()}
+        onTabRename={asMock<(tabId: string) => void>(onTabRename)}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText('File1.md'));
+    const menuItem = screen.getByText('folderTree.rename');
+    expect(menuItem).toBeInTheDocument();
+    fireEvent.click(menuItem);
+    // Handler is called, which sets contextMenu to null (menu closes)
+    expect(onTabRename).toHaveBeenCalledWith('tab1');
+  });
+
+  // T-TB-18: right-click on vertical tab shows context menu
+  it('T-TB-18: right-click on vertical tab shows context menu', () => {
+    const onTabRename = vi.fn();
+    render(
+      <TabBar
+        {...defaultProps()}
+        layout="vertical"
+        onTabRename={asMock<(tabId: string) => void>(onTabRename)}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText('File2.md'));
+    expect(screen.getByText('folderTree.rename')).toBeInTheDocument();
+  });
+
+  // T-TB-19: vertical Rename menu item calls onTabRename with correct ID
+  it('T-TB-19: vertical Rename calls onTabRename with correct tab ID', () => {
+    const onTabRename = vi.fn();
+    render(
+      <TabBar
+        {...defaultProps()}
+        layout="vertical"
+        onTabRename={asMock<(tabId: string) => void>(onTabRename)}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText('File1.md'));
+    fireEvent.click(screen.getByText('folderTree.rename'));
+    expect(onTabRename).toHaveBeenCalledWith('tab1');
+  });
+
+  // T-TB-20: no context menu rendered when onTabRename is not provided
+  it('T-TB-20: no context menu when onTabRename is not provided', () => {
+    render(<TabBar {...defaultProps()} />);
+    fireEvent.contextMenu(screen.getByText('File1.md'));
+    expect(screen.queryByText('folderTree.rename')).not.toBeInTheDocument();
   });
 });

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -70,6 +70,7 @@ export const useAppState = () => {
     saveTabAs,
     createNewTab,
     renameFile,
+    updateTabTitle,
   } = useTabsDesktop();
 
   // Zoom management
@@ -228,7 +229,7 @@ export const useAppState = () => {
   };
 
   // Rename dialog state
-  const [renameDialog, setRenameDialog] = useState<{ open: boolean; filePath: string; currentName: string }>({
+  const [renameDialog, setRenameDialog] = useState<{ open: boolean; filePath: string; currentName: string; tabId?: string }>({
     open: false, filePath: '', currentName: '',
   });
 
@@ -239,20 +240,35 @@ export const useAppState = () => {
 
   const handleRenameConfirm = useCallback(async (newName: string) => {
     try {
-      await renameFile(renameDialog.filePath, newName);
+      if (renameDialog.tabId && !renameDialog.filePath) {
+        // Unsaved tab: only update title
+        updateTabTitle(renameDialog.tabId, newName);
+      } else {
+        // Saved file (from tab or folder tree): rename on filesystem
+        await renameFile(renameDialog.filePath, newName);
+        folderTreeRefreshTree();
+      }
       setRenameDialog({ open: false, filePath: '', currentName: '' });
-      folderTreeRefreshTree();
       setSnackbar({ open: true, message: t('folderTree.renameSuccess'), severity: 'success' });
     } catch (error) {
       console.error('Failed to rename file:', error);
       const msg = error instanceof Error ? error.message : t('folderTree.renameFailed');
       setSnackbar({ open: true, message: msg, severity: 'error' });
     }
-  }, [renameFile, renameDialog.filePath, folderTreeRefreshTree, t]);
+  }, [renameFile, renameDialog.filePath, renameDialog.tabId, updateTabTitle, folderTreeRefreshTree, t]);
 
   const handleRenameCancel = useCallback(() => {
     setRenameDialog({ open: false, filePath: '', currentName: '' });
   }, []);
+
+  const handleTabRenameRequest = useCallback((tabId: string) => {
+    const tab = tabs.find(t => t.id === tabId);
+    if (!tab) return;
+    const currentName = tab.filePath
+      ? tab.filePath.substring(tab.filePath.lastIndexOf('/') + 1)
+      : tab.title;
+    setRenameDialog({ open: true, filePath: tab.filePath || '', currentName, tabId });
+  }, [tabs]);
 
   const handleFolderTreeFileClick = useCallback(async (filePath: string) => {
     try {
@@ -468,6 +484,7 @@ export const useAppState = () => {
     handleRenameRequest,
     handleRenameConfirm,
     handleRenameCancel,
+    handleTabRenameRequest,
     setGlobalVariables,
     setTabLayout,
     setViewMode,


### PR DESCRIPTION
## Summary

- Add a right-click context menu on editor tabs with a "Rename" option
- Reuse the existing `RenameDialog` and `renameFile()` infrastructure from the file explorer
- Support two rename cases:
  - **Saved files**: renames the file on disk, updates tab title/path, and refreshes the folder tree
  - **Unsaved tabs**: updates only the tab display title (no filesystem operation)
- Works in both horizontal and vertical tab layouts
- Monaco editor undo/redo history is preserved since tab IDs (used as model keys) remain unchanged

## Test plan

- [x] Unit tests pass (28/28 — TabBar 20 + RenameDialog 8)
- [x] Manual: Right-click a saved file tab → Rename → verify file renamed on disk, tab title updated, folder
tree refreshed
- [ ] Manual: Right-click an unsaved tab → Rename → verify only tab title changes
- [ ] Manual: Validate empty name and `/` `\` characters show errors
- [ ] Manual: Confirm undo/redo history persists after rename
- [ ] Manual: Verify both horizontal and vertical tab layouts