### PR TITLE
Fix for file change detection not working properly on Windows

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -516,7 +516,7 @@ const MarkdownEditor: React.FC<EditorProps> = ({
   };
 
   const handleEditorChange = (value: string | undefined) => {
-    if (value !== undefined) {
+    if (value !== undefined && value !== content) {
       onChange(value);
     }
   };

--- a/src/hooks/__tests__/useFileChangeDetection.test.ts
+++ b/src/hooks/__tests__/useFileChangeDetection.test.ts
@@ -17,7 +17,7 @@ import type { Tab } from '../../types/tab';
 import { asMock } from '../../test-utils';
 
 describe('useFileChangeDetection', () => {
-  let updateTabContent: ReturnType<typeof vi.fn>;
+  let reloadTabContent: ReturnType<typeof vi.fn>;
   let updateTabFileHash: ReturnType<typeof vi.fn>;
   let setActiveTab: ReturnType<typeof vi.fn>;
 
@@ -26,7 +26,7 @@ describe('useFileChangeDetection', () => {
   ];
 
   beforeEach(() => {
-    updateTabContent = vi.fn();
+    reloadTabContent = vi.fn();
     updateTabFileHash = vi.fn();
     setActiveTab = vi.fn();
   });
@@ -35,7 +35,7 @@ describe('useFileChangeDetection', () => {
     tabs,
     activeTab: tabs[0],
     isInitialized: true,
-    updateTabContent: asMock<(tabId: string, content: string) => void>(updateTabContent),
+    reloadTabContent: asMock<(tabId: string, content: string) => void>(reloadTabContent),
     updateTabFileHash: asMock<(tabId: string) => void>(updateTabFileHash),
     setActiveTab: asMock<(tabId: string) => void>(setActiveTab),
   });
@@ -112,7 +112,7 @@ describe('useFileChangeDetection', () => {
         tabs: currentTabs,
         activeTab: currentTabs[0],
         isInitialized: true,
-        updateTabContent: asMock<(tabId: string, content: string) => void>(updateTabContent),
+        reloadTabContent: asMock<(tabId: string, content: string) => void>(reloadTabContent),
         updateTabFileHash: asMock<(tabId: string) => void>(updateTabFileHash),
         setActiveTab: asMock<(tabId: string) => void>(setActiveTab),
       }),
@@ -138,5 +138,38 @@ describe('useFileChangeDetection', () => {
     // If tabs dependency was missing, the listener would have stale tabs and not find tab2
     asMock<typeof desktopApi.readFileFromPath>(desktopApi.readFileFromPath as ReturnType<typeof vi.fn>);
     (desktopApi.readFileFromPath as ReturnType<typeof vi.fn>).mockResolvedValueOnce('updated content');
+  });
+
+  // T-FCD-06: Regression test - polling stops while dialog is open
+  it('T-FCD-06: does not poll while file change dialog is open', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { detectFileChange } = await import('../../utils/fileChangeDetection');
+      const mockDetect = detectFileChange as ReturnType<typeof vi.fn>;
+      mockDetect.mockClear();
+
+      const { result } = renderHook(() => useFileChangeDetection(defaultParams()));
+
+      // Open the dialog
+      act(() => {
+        result.current.setFileChangeDialog({
+          open: true,
+          fileName: 'test.md',
+          onReload: vi.fn(),
+          onCancel: vi.fn(),
+        });
+      });
+
+      // Advance timers past the 5-second polling interval
+      await act(async () => {
+        vi.advanceTimersByTime(10000);
+      });
+
+      // detectFileChange should NOT have been called while dialog is open
+      expect(mockDetect).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/hooks/__tests__/useFileChangeDetection.test.ts
+++ b/src/hooks/__tests__/useFileChangeDetection.test.ts
@@ -19,6 +19,7 @@ import { asMock } from '../../test-utils';
 describe('useFileChangeDetection', () => {
   let reloadTabContent: ReturnType<typeof vi.fn>;
   let updateTabFileHash: ReturnType<typeof vi.fn>;
+  let setTabModified: ReturnType<typeof vi.fn>;
   let setActiveTab: ReturnType<typeof vi.fn>;
 
   const tabs: Tab[] = [
@@ -28,6 +29,7 @@ describe('useFileChangeDetection', () => {
   beforeEach(() => {
     reloadTabContent = vi.fn();
     updateTabFileHash = vi.fn();
+    setTabModified = vi.fn();
     setActiveTab = vi.fn();
   });
 
@@ -37,6 +39,7 @@ describe('useFileChangeDetection', () => {
     isInitialized: true,
     reloadTabContent: asMock<(tabId: string, content: string) => void>(reloadTabContent),
     updateTabFileHash: asMock<(tabId: string) => void>(updateTabFileHash),
+    setTabModified: asMock<(tabId: string, isModified: boolean) => void>(setTabModified),
     setActiveTab: asMock<(tabId: string) => void>(setActiveTab),
   });
 
@@ -114,6 +117,7 @@ describe('useFileChangeDetection', () => {
         isInitialized: true,
         reloadTabContent: asMock<(tabId: string, content: string) => void>(reloadTabContent),
         updateTabFileHash: asMock<(tabId: string) => void>(updateTabFileHash),
+        setTabModified: asMock<(tabId: string, isModified: boolean) => void>(setTabModified),
         setActiveTab: asMock<(tabId: string) => void>(setActiveTab),
       }),
     );
@@ -138,6 +142,64 @@ describe('useFileChangeDetection', () => {
     // If tabs dependency was missing, the listener would have stale tabs and not find tab2
     asMock<typeof desktopApi.readFileFromPath>(desktopApi.readFileFromPath as ReturnType<typeof vi.fn>);
     (desktopApi.readFileFromPath as ReturnType<typeof vi.fn>).mockResolvedValueOnce('updated content');
+  });
+
+  // T-FCD-07: Regression test - cancel marks tab as modified
+  it('T-FCD-07: onCancel calls detail onCancel and closes dialog', async () => {
+    const detailOnCancel = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useFileChangeDetection(defaultParams()));
+
+    // Open dialog via event
+    act(() => {
+      const event = new CustomEvent('fileChangeDetected', {
+        detail: {
+          fileName: 'test.md',
+          tabId: 'tab1',
+          onCancel: detailOnCancel,
+        },
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(result.current.fileChangeDialog.open).toBe(true);
+
+    // Click cancel
+    await act(async () => {
+      await result.current.fileChangeDialog.onCancel();
+    });
+
+    // Detail's onCancel should have been called
+    expect(detailOnCancel).toHaveBeenCalledTimes(1);
+    // Dialog should be closed
+    expect(result.current.fileChangeDialog.open).toBe(false);
+  });
+
+  // T-FCD-08: Regression test - dialog closes even if onCancel throws
+  it('T-FCD-08: dialog closes even when detail onCancel throws', async () => {
+    const detailOnCancel = vi.fn().mockRejectedValue(new Error('save failed'));
+    const { result } = renderHook(() => useFileChangeDetection(defaultParams()));
+
+    // Open dialog via event
+    act(() => {
+      const event = new CustomEvent('fileChangeDetected', {
+        detail: {
+          fileName: 'test.md',
+          tabId: 'tab1',
+          onCancel: detailOnCancel,
+        },
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(result.current.fileChangeDialog.open).toBe(true);
+
+    // Click cancel (onCancel throws internally)
+    await act(async () => {
+      await result.current.fileChangeDialog.onCancel();
+    });
+
+    // Dialog must still close despite the error
+    expect(result.current.fileChangeDialog.open).toBe(false);
   });
 
   // T-FCD-06: Regression test - polling stops while dialog is open

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -63,6 +63,7 @@ export const useAppState = () => {
     removeTab,
     setActiveTab,
     updateTabContent,
+    reloadTabContent,
     updateTabFileHash,
     reorderTabs,
     openFile,
@@ -136,7 +137,7 @@ export const useAppState = () => {
     tabs,
     activeTab,
     isInitialized,
-    updateTabContent,
+    reloadTabContent,
     updateTabFileHash,
     setActiveTab,
   });

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -65,6 +65,7 @@ export const useAppState = () => {
     updateTabContent,
     reloadTabContent,
     updateTabFileHash,
+    setTabModified,
     reorderTabs,
     openFile,
     saveTab,
@@ -139,6 +140,7 @@ export const useAppState = () => {
     isInitialized,
     reloadTabContent,
     updateTabFileHash,
+    setTabModified,
     setActiveTab,
   });
 

--- a/src/hooks/useFileChangeDetection.ts
+++ b/src/hooks/useFileChangeDetection.ts
@@ -9,6 +9,7 @@ interface UseFileChangeDetectionParams {
   isInitialized: boolean;
   reloadTabContent: (tabId: string, content: string) => void;
   updateTabFileHash: (tabId: string, hashInfo: { hash: string; modified_time: number; file_size: number }) => void;
+  setTabModified: (tabId: string, isModified: boolean) => void;
   setActiveTab: (tabId: string) => void;
 }
 
@@ -18,6 +19,7 @@ export const useFileChangeDetection = ({
   isInitialized,
   reloadTabContent,
   updateTabFileHash,
+  setTabModified,
   setActiveTab,
 }: UseFileChangeDetectionParams) => {
   const [fileChangeDialog, setFileChangeDialog] = useState<{
@@ -69,18 +71,11 @@ export const useFileChangeDetection = ({
           setFileChangeDialog(prev => ({ ...prev, open: false }));
         },
         onCancel: async () => {
-          onCancel();
           try {
-            const currentTabs = tabs;
-            const tab = currentTabs.find(t => t.id === tabId);
-            if (tab && tab.filePath && !tab.isNew) {
-              const newHashInfo = await desktopApi.getFileHash(tab.filePath);
-              updateTabFileHash(tabId, newHashInfo);
-            }
+            await onCancel();
           } catch (error) {
-            console.warn('Failed to update file hash after cancel:', error);
+            console.error('Failed to execute cancel handler:', error);
           }
-          setActiveTab(tabId);
           setFileChangeDialog(prev => ({ ...prev, open: false }));
         },
       });
@@ -117,6 +112,7 @@ export const useFileChangeDetection = ({
               }
             },
             onCancel: async () => {
+              setTabModified(tab.id, true);
               try {
                 const newHashInfo = await desktopApi.getFileHash(tab.filePath!);
                 updateTabFileHash(tab.id, newHashInfo);
@@ -132,7 +128,7 @@ export const useFileChangeDetection = ({
     } catch (error) {
       console.warn(`Failed to check file change during ${source}:`, error);
     }
-  }, [reloadTabContent, updateTabFileHash, setActiveTab]);
+  }, [reloadTabContent, updateTabFileHash, setTabModified, setActiveTab]);
 
   // Periodic file change check (every 5 seconds)
   // Stop polling while the file change dialog is open to prevent re-triggering

--- a/src/hooks/useFileChangeDetection.ts
+++ b/src/hooks/useFileChangeDetection.ts
@@ -7,7 +7,7 @@ interface UseFileChangeDetectionParams {
   tabs: Tab[];
   activeTab: Tab | null;
   isInitialized: boolean;
-  updateTabContent: (tabId: string, content: string) => void;
+  reloadTabContent: (tabId: string, content: string) => void;
   updateTabFileHash: (tabId: string, hashInfo: { hash: string; modified_time: number; file_size: number }) => void;
   setActiveTab: (tabId: string) => void;
 }
@@ -16,7 +16,7 @@ export const useFileChangeDetection = ({
   tabs,
   activeTab,
   isInitialized,
-  updateTabContent,
+  reloadTabContent,
   updateTabFileHash,
   setActiveTab,
 }: UseFileChangeDetectionParams) => {
@@ -46,14 +46,20 @@ export const useFileChangeDetection = ({
             const tab = currentTabs.find(t => t.id === tabId);
 
             if (tab && tab.filePath && !tab.isNew) {
-              const fileContent = await desktopApi.readFileFromPath(tab.filePath);
-              updateTabContent(tabId, fileContent);
+              // Use readFileByPath (custom Tauri command) instead of readFileFromPath
+              // (FS plugin) to avoid scope/path issues on Windows
+              const fileResult = await desktopApi.readFileByPath(tab.filePath);
+              if (fileResult.error) {
+                console.error('Failed to read file for reload:', fileResult.error);
+              } else {
+                reloadTabContent(tabId, fileResult.content);
 
-              try {
-                const newHashInfo = await desktopApi.getFileHash(tab.filePath);
-                updateTabFileHash(tabId, newHashInfo);
-              } catch (error) {
-                console.warn('Failed to update file hash after reload:', error);
+                try {
+                  const newHashInfo = await desktopApi.getFileHash(tab.filePath);
+                  updateTabFileHash(tabId, newHashInfo);
+                } catch (error) {
+                  console.warn('Failed to update file hash after reload:', error);
+                }
               }
             }
             setActiveTab(tabId);
@@ -84,7 +90,7 @@ export const useFileChangeDetection = ({
     return () => {
       window.removeEventListener('fileChangeDetected', handleFileChangeDetected);
     };
-  }, [tabs, updateTabContent, updateTabFileHash, setActiveTab, isInitialized]);
+  }, [tabs, reloadTabContent, updateTabFileHash, setActiveTab, isInitialized]);
 
   // Common file change detection handler
   const checkFileChange = useCallback(async (tab: Tab, source: string) => {
@@ -99,10 +105,12 @@ export const useFileChangeDetection = ({
             tabId: tab.id,
             onReload: async () => {
               try {
-                const fileContent = await desktopApi.readFileFromPath(tab.filePath!);
-                updateTabContent(tab.id, fileContent);
-                const newHashInfo = await desktopApi.getFileHash(tab.filePath!);
-                updateTabFileHash(tab.id, newHashInfo);
+                const fileResult = await desktopApi.readFileByPath(tab.filePath!);
+                if (!fileResult.error) {
+                  reloadTabContent(tab.id, fileResult.content);
+                  const newHashInfo = await desktopApi.getFileHash(tab.filePath!);
+                  updateTabFileHash(tab.id, newHashInfo);
+                }
                 setActiveTab(tab.id);
               } catch (error) {
                 console.error('Failed to reload file:', error);
@@ -124,11 +132,12 @@ export const useFileChangeDetection = ({
     } catch (error) {
       console.warn(`Failed to check file change during ${source}:`, error);
     }
-  }, [updateTabContent, updateTabFileHash, setActiveTab]);
+  }, [reloadTabContent, updateTabFileHash, setActiveTab]);
 
   // Periodic file change check (every 5 seconds)
+  // Stop polling while the file change dialog is open to prevent re-triggering
   useEffect(() => {
-    if (!isInitialized) return;
+    if (!isInitialized || fileChangeDialog.open) return;
 
     const interval = setInterval(async () => {
       if (activeTab && !activeTab.isNew && activeTab.filePath) {
@@ -137,7 +146,7 @@ export const useFileChangeDetection = ({
     }, 5000);
 
     return () => clearInterval(interval);
-  }, [isInitialized, activeTab, checkFileChange]);
+  }, [isInitialized, activeTab, checkFileChange, fileChangeDialog.open]);
 
   return {
     fileChangeDialog,

--- a/src/hooks/useTabsDesktop.ts
+++ b/src/hooks/useTabsDesktop.ts
@@ -47,6 +47,10 @@ export const useTabsDesktop = () => {
     dispatch({ type: 'UPDATE_TAB_CONTENT', payload: { id, content } });
   }, []);
 
+  const reloadTabContent = useCallback((id: string, content: string) => {
+    dispatch({ type: 'RELOAD_TAB_CONTENT', payload: { id, content } });
+  }, []);
+
   const updateTabTitle = useCallback((id: string, title: string) => {
     dispatch({ type: 'UPDATE_TAB_TITLE', payload: { id, title } });
   }, []);
@@ -168,9 +172,8 @@ export const useTabsDesktop = () => {
               fileName: tab.title,
               tabId: id,
               onReload: async (newContent: string) => {
-                // Update content
-                updateTabContent(id, newContent);
-                setTabModified(id, false);
+                // Update content (reload sets isModified: false)
+                reloadTabContent(id, newContent);
 
                 // Update file hash info
                 try {
@@ -278,7 +281,7 @@ export const useTabsDesktop = () => {
       console.error('Error details:', error);
       return false;
     }
-  }, [state.tabs, setTabModified, setTabFilePath, updateTabTitle, setTabNew, updateTabContent]);
+  }, [state.tabs, setTabModified, setTabFilePath, updateTabTitle, setTabNew, updateTabContent, reloadTabContent]);
 
   const saveTabAs = useCallback(async (id: string) => {
     const tab = state.tabs.find(t => t.id === id);
@@ -441,6 +444,7 @@ export const useTabsDesktop = () => {
     removeTab,
     setActiveTab,
     updateTabContent,
+    reloadTabContent,
     updateTabTitle,
     setTabModified,
     setTabFilePath,

--- a/src/reducers/__tests__/tabReducer.test.ts
+++ b/src/reducers/__tests__/tabReducer.test.ts
@@ -99,6 +99,22 @@ describe('tabReducer', () => {
     expect(result.tabs[1].isModified).toBe(false);
   });
 
+  // T-TR-07b
+  it('RELOAD_TAB_CONTENT sets content but keeps isModified false', () => {
+    const tab1 = createTab({ id: 't1', content: 'old', isModified: true });
+    const tab2 = createTab({ id: 't2', content: 'keep', isModified: true });
+    const state = stateWith(tab1, tab2);
+
+    const result = tabReducer(state, {
+      type: 'RELOAD_TAB_CONTENT',
+      payload: { id: 't1', content: 'reloaded from disk' },
+    });
+    expect(result.tabs[0].content).toBe('reloaded from disk');
+    expect(result.tabs[0].isModified).toBe(false);
+    expect(result.tabs[1].content).toBe('keep');
+    expect(result.tabs[1].isModified).toBe(true);
+  });
+
   // T-TR-08
   it('UPDATE_TAB_TITLE updates title and leaves other tabs unchanged', () => {
     const tab1 = createTab({ id: 't1', title: 'Old Title' });

--- a/src/reducers/tabReducer.ts
+++ b/src/reducers/tabReducer.ts
@@ -55,6 +55,16 @@ export const tabReducer = (state: TabState, action: TabAction): TabState => {
         ),
       };
 
+    case 'RELOAD_TAB_CONTENT':
+      return {
+        ...state,
+        tabs: state.tabs.map(tab =>
+          tab.id === action.payload.id
+            ? { ...tab, content: action.payload.content, isModified: false }
+            : tab
+        ),
+      };
+
     case 'UPDATE_TAB_TITLE':
       return {
         ...state,

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -28,6 +28,7 @@ export type TabAction =
   | { type: 'REMOVE_TAB'; payload: { id: string } }
   | { type: 'SET_ACTIVE_TAB'; payload: { id: string | null } }
   | { type: 'UPDATE_TAB_CONTENT'; payload: { id: string; content: string } }
+  | { type: 'RELOAD_TAB_CONTENT'; payload: { id: string; content: string } }
   | { type: 'UPDATE_TAB_TITLE'; payload: { id: string; title: string } }
   | { type: 'SET_TAB_MODIFIED'; payload: { id: string; isModified: boolean } }
   | { type: 'SET_TAB_FILE_PATH'; payload: { id: string; filePath: string } }

--- a/src/utils/__tests__/fileChangeDetection.test.ts
+++ b/src/utils/__tests__/fileChangeDetection.test.ts
@@ -59,15 +59,16 @@ describe('detectFileChange', () => {
     expect(await detectFileChange(tab)).toBe(true);
   });
 
-  // T-FC-03
-  it('returns true when modified time differs', async () => {
+  // T-FC-03: modified_time differs but hash is the same → not changed
+  // (Windows/NTFS can update modified_time without content changes)
+  it('returns false when only modified time differs but hash matches', async () => {
     vi.mocked(desktopApi.getFileHash).mockResolvedValue({
       hash: 'abc123',
       modified_time: 2000,
       file_size: 512,
     });
     const tab = createTab();
-    expect(await detectFileChange(tab)).toBe(true);
+    expect(await detectFileChange(tab)).toBe(false);
   });
 
   // T-FC-04

--- a/src/utils/fileChangeDetection.ts
+++ b/src/utils/fileChangeDetection.ts
@@ -22,23 +22,23 @@ export async function detectFileChange(tab: Tab): Promise<boolean> {
     // Get current file hash
     const currentHashInfo = await desktopApi.getFileHash(tab.filePath);
 
-    // Incremental checks
-    // 1. File size check (fast)
+    // Content-based change detection
+    // NOTE: modified_time is intentionally NOT used for change detection.
+    // Windows/NTFS can update timestamps without content changes
+    // (delayed metadata flush, AV scanning, etc.), causing false positives
+    // that lead to infinite dialog loops.
+
+    // 1. File size check (fast) — size change always means content change
     if (currentHashInfo.file_size !== tab.fileHashInfo.file_size) {
       return true;
     }
 
-    // 2. Last modified time check (fast)
-    if (currentHashInfo.modified_time !== tab.fileHashInfo.modified_time) {
-      return true;
-    }
-
-    // 3. Hash value check (only when needed)
+    // 2. Hash value check — definitive content comparison
     if (currentHashInfo.hash !== tab.fileHashInfo.hash) {
       return true;
     }
 
-    // No changes
+    // No content changes
     return false;
   } catch (error) {
     console.error('Failed to detect file change:', error);


### PR DESCRIPTION
### Problem
File change detection was not functioning correctly on Windows when a file was saved or modified externally.

### Changes
- Improved file change detection logic (useFileChangeDetection.ts, fileChangeDetection.ts): Revised the change detection logic to work correctly on Windows
- Extended tab state management (tabReducer.ts, tab.ts): Added a new state field to tabs to integrate with change detection
- Adjusted detection handling during tab operations (useTabsDesktop.ts, useAppState.ts, Editor.tsx): Ensured change detection triggers correctly during tab switching and file
operations

### Added regression tests

- Added test cases for useFileChangeDetection and tabReducer to prevent future regressions of this fix