### PR TITLE
Update editor mode toggle icons with custom SVG designs

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,6 +1,28 @@
 import React, { useState, useEffect } from 'react';
-import { AppBar, Toolbar, Typography, IconButton, Menu, MenuItem, ToggleButton, ToggleButtonGroup } from '@mui/material';
-import { FolderOpen, Save, SaveAlt, MoreVert, ViewColumn, Edit, Visibility, Add, Settings as SettingsIcon2, HelpOutline, Schedule, FormatListBulleted, AccountTree } from '@mui/icons-material';
+import { AppBar, Toolbar, Typography, IconButton, Menu, MenuItem, ToggleButton, ToggleButtonGroup, SvgIcon } from '@mui/material';
+import { FolderOpen, Save, SaveAlt, MoreVert, Add, Settings as SettingsIcon2, HelpOutline, Schedule, FormatListBulleted, AccountTree } from '@mui/icons-material';
+
+const SplitViewIcon = () => (
+  <SvgIcon viewBox="0 0 512 512">
+    <path d="M413.4,18.64H98.6c-44.16,0-79.96,35.8-79.96,79.96v314.81c0,44.16,35.8,79.96,79.96,79.96h314.81c44.16,0,79.96-35.8,79.96-79.96V98.6c0-44.16-35.8-79.96-79.96-79.96ZM42.64,413.4V98.6c0-30.86,25.1-55.96,55.96-55.96h145.4v426.73H98.6c-30.86,0-55.96-25.1-55.96-55.96ZM469.36,413.4c0,30.86-25.1,55.96-55.96,55.96h-145.4V42.64h145.4c30.86,0,55.96,25.1,55.96,55.96v314.81Z" />
+  </SvgIcon>
+);
+
+const EditViewIcon = () => (
+  <SvgIcon viewBox="0 0 512 512">
+    <rect x="110.55" y="167.42" width="318.13" height="156.26" transform="translate(-94.66 262.56) rotate(-45)" />
+    <path d="M447.72,177.93l-110.49-110.49,44.13-44.13c10.34-10.34,27.12-10.34,37.46,0l73.03,73.03c10.34,10.34,10.34,27.12,0,37.46l-44.13,44.13Z" />
+    <polygon points="36.56 478.6 90.95 313.72 201.44 424.21 36.56 478.6" />
+  </SvgIcon>
+);
+
+const PreviewIcon = () => (
+  <SvgIcon viewBox="0 0 512 512">
+    <path d="M256,147.09c-29.09,0-56.44,11.33-77.01,31.9-20.57,20.57-31.9,47.92-31.9,77.01s11.33,56.44,31.9,77.01,47.92,31.9,77.01,31.9,56.44-11.33,77.01-31.9c20.57-20.57,31.9-47.92,31.9-77.01s-11.33-56.44-31.9-77.01c-20.57-20.57-47.92-31.9-77.01-31.9ZM238.31,198.56c-20.84,6.55-35.84,27.46-37.78,43.08-.75,6.07-5.93,10.52-11.89,10.52-.49,0-.99-.03-1.49-.09-6.58-.82-11.25-6.81-10.43-13.39,3.38-27.25,26.77-54.34,54.4-63.02,6.32-1.99,13.06,1.53,15.04,7.85,1.99,6.32-1.53,13.06-7.85,15.04Z" />
+    <path d="M256,109.72C116.93,109.72,4.19,256,4.19,256c0,0,112.74,146.28,251.81,146.28s251.81-146.28,251.81-146.28c0,0-112.74-146.28-251.81-146.28ZM256,388.91c-73.4,0-132.91-59.51-132.91-132.91s59.51-132.91,132.91-132.91,132.91,59.51,132.91,132.91-59.51,132.91-132.91,132.91Z" />
+  </SvgIcon>
+);
+
 import { RecentFile } from '../types/recentFiles';
 import { storeApi } from '../api/storeApi';
 import { Tab } from '../types/tab';
@@ -98,16 +120,26 @@ const AppHeader: React.FC<AppHeaderProps> = ({
             }
           }}
           size="small"
-          sx={{ mr: 1 }}
+          sx={{
+            mr: 1,
+            '& .MuiToggleButton-root': {
+              color: 'inherit',
+              opacity: 0.5,
+              '&.Mui-selected': {
+                opacity: 1,
+                color: 'inherit',
+              },
+            },
+          }}
         >
           <ToggleButton value="split" aria-label={t('buttons.splitView')}>
-            <ViewColumn />
+            <SplitViewIcon />
           </ToggleButton>
           <ToggleButton value="editor" aria-label={t('buttons.editorOnly')}>
-            <Edit />
+            <EditViewIcon />
           </ToggleButton>
           <ToggleButton value="preview" aria-label={t('buttons.previewOnly')}>
-            <Visibility />
+            <PreviewIcon />
           </ToggleButton>
         </ToggleButtonGroup>
 


### PR DESCRIPTION
## Summary
- Replace the three editor mode toggle button icons (split view, edit view, preview view) in the AppHeader with custom-designed SVG icons using MUI's `SvgIcon` component
- Adjust toggle button color styling to use `color: inherit` with opacity-based active/inactive states, matching the adjacent toolbar IconButtons

## Changes
- **Split view**: `ViewColumn` (MUI) → custom split-panel icon (`SplitViewIcon`)
- **Edit view**: `Edit` (MUI) → custom pencil icon (`EditViewIcon`)
- **Preview view**: `Visibility` (MUI) → custom eye icon (`PreviewIcon`)
- Active state: `opacity: 1`, Inactive state: `opacity: 0.5`

Before:
<img width="291" height="57" alt="スクリーンショット 2026-04-12 19 58 07" src="https://github.com/user-attachments/assets/5e4e9a54-e851-465c-9e00-17e4e8758a68" />

After:
<img width="284" height="58" alt="スクリーンショット 2026-04-12 19 57 49" src="https://github.com/user-attachments/assets/1576e535-8c8a-4503-901c-bb917909158f" />