### PR TITLE
Fix preview scroll position not preserved when switching tabs

### DIFF
--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -132,13 +132,39 @@ const AppContent: React.FC<AppContentProps> = ({
   focusRequestId,
   t,
 }) => {
+  const scrollFractionMap = useRef<Map<string, number>>(new Map());
+  const activeTabIdRef = useRef(activeTabId);
+  activeTabIdRef.current = activeTabId;
   const [scrollFraction, setScrollFraction] = useState(0);
   const [revealLineRequest, setRevealLineRequest] = useState<{ lineNumber: number; requestId: number }>({ lineNumber: 0, requestId: 0 });
 
   const headings = useOutlineHeadings(activeTab?.content);
 
+  // Restore scroll position when switching tabs
+  useEffect(() => {
+    if (activeTabId) {
+      setScrollFraction(scrollFractionMap.current.get(activeTabId) ?? 0);
+    }
+  }, [activeTabId]);
+
+  // Clean up scroll entries for closed tabs
+  useEffect(() => {
+    const currentTabIds = new Set(tabs.map(t => t.id));
+    for (const key of scrollFractionMap.current.keys()) {
+      if (!currentTabIds.has(key)) {
+        scrollFractionMap.current.delete(key);
+      }
+    }
+  }, [tabs]);
+
+  // Use ref for activeTabId to avoid stale closure in Editor's scroll listener.
+  // Editor.tsx registers onScrollChange once at mount, so the callback reference must be stable.
   const handleEditorScrollChange = useCallback((fraction: number) => {
     setScrollFraction(fraction);
+    const tabId = activeTabIdRef.current;
+    if (tabId) {
+      scrollFractionMap.current.set(tabId, fraction);
+    }
   }, []);
 
   const handleHeadingClick = useCallback((lineNumber: number) => {
@@ -488,6 +514,8 @@ const AppContent: React.FC<AppContentProps> = ({
                     onContentChange={onContentChange}
                     filePath={activeTab.filePath}
                     renderingSettings={renderingSettings}
+                    scrollFraction={scrollFraction}
+                    onScrollChange={handleEditorScrollChange}
                     viewMode="preview"
                   />
                 </Box>

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -22,6 +22,7 @@ interface PreviewProps {
   zoomLevel?: number;
   onContentChange?: (newContent: string) => void;
   scrollFraction?: number;
+  onScrollChange?: (fraction: number) => void;
   filePath?: string;
   renderingSettings?: RenderingSettings;
   viewMode?: 'split' | 'editor' | 'preview';
@@ -43,7 +44,7 @@ function resolveRelativePath(baseDirPath: string, relativePath: string): string 
   return '/' + resolved.join('/');
 }
 
-const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, globalVariables = {}, zoomLevel = 1.0, onContentChange, scrollFraction, filePath, renderingSettings = DEFAULT_RENDERING_SETTINGS, viewMode = 'split' }) => {
+const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, globalVariables = {}, zoomLevel = 1.0, onContentChange, scrollFraction, onScrollChange, filePath, renderingSettings = DEFAULT_RENDERING_SETTINGS, viewMode = 'split' }) => {
   const isMarp = renderingSettings.enableMarp && contentIsMarp(content);
   const previewRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -311,6 +312,20 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
       }
     }
   }, [scrollFraction]);
+
+  // Report scroll position back to parent (used in preview-only mode)
+  useEffect(() => {
+    if (!onScrollChange || !scrollContainerRef.current) return;
+    const container = scrollContainerRef.current;
+    const handleScroll = () => {
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      if (maxScroll > 0) {
+        onScrollChange(container.scrollTop / maxScroll);
+      }
+    };
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, [onScrollChange]);
 
   const handleExportHTML = async () => {
     try {

--- a/src/components/__tests__/AppContent.test.tsx
+++ b/src/components/__tests__/AppContent.test.tsx
@@ -1,13 +1,21 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { vi, describe, it, expect } from 'vitest';
+
+// Capture onScrollChange from Editor so tests can simulate scroll events
+let capturedOnScrollChange: ((fraction: number) => void) | undefined;
 
 // Mock heavy child components
 vi.mock('../Editor', () => ({
-  default: () => <div data-testid="editor">Editor</div>,
+  default: ({ onScrollChange }: { onScrollChange?: (fraction: number) => void }) => {
+    capturedOnScrollChange = onScrollChange;
+    return <div data-testid="editor">Editor</div>;
+  },
 }));
 
 vi.mock('../Preview', () => ({
-  default: () => <div data-testid="preview">Preview</div>,
+  default: ({ scrollFraction }: { scrollFraction?: number }) => (
+    <div data-testid="preview" data-scroll-fraction={scrollFraction ?? ''}>Preview</div>
+  ),
 }));
 
 vi.mock('../TabBar', () => ({
@@ -144,5 +152,59 @@ describe('AppContent', () => {
   it('T-AC-10: shows loading when settings not loaded', () => {
     render(<AppContent {...createDefaultProps()} isSettingsLoaded={false} />);
     expect(screen.getByText('app.loading')).toBeInTheDocument();
+  });
+
+  // T-AC-11: new tab starts with scrollFraction 0
+  it('T-AC-11: new tab starts with scrollFraction 0', () => {
+    const tab = { id: 'new-tab', title: 'Untitled', content: '', isModified: false, isNew: true };
+    render(
+      <AppContent
+        {...createDefaultProps()}
+        tabs={[tab]}
+        activeTabId="new-tab"
+        activeTab={tab}
+      />,
+    );
+    const preview = screen.getByTestId('preview');
+    expect(preview.getAttribute('data-scroll-fraction')).toBe('0');
+  });
+
+  // T-AC-12: scroll position is preserved per tab when switching
+  it('T-AC-12: scroll position preserved per tab on switch', () => {
+    const tab1 = { id: 'tab1', title: 'a.md', content: '# A', isModified: false, isNew: false };
+    const tab2 = { id: 'tab2', title: 'b.md', content: '# B', isModified: false, isNew: false };
+    const allTabs = [tab1, tab2];
+
+    // Render with tab1 active
+    const { rerender } = render(
+      <AppContent {...createDefaultProps()} tabs={allTabs} activeTabId="tab1" activeTab={tab1} />,
+    );
+
+    // Simulate scrolling tab1 to 0.7
+    act(() => { capturedOnScrollChange?.(0.7); });
+
+    // Switch to tab2
+    rerender(
+      <AppContent {...createDefaultProps()} tabs={allTabs} activeTabId="tab2" activeTab={tab2} />,
+    );
+    // tab2 should have scrollFraction 0 (never scrolled)
+    expect(screen.getByTestId('preview').getAttribute('data-scroll-fraction')).toBe('0');
+
+    // Simulate scrolling tab2 to 0.3
+    act(() => { capturedOnScrollChange?.(0.3); });
+
+    // Switch back to tab1
+    rerender(
+      <AppContent {...createDefaultProps()} tabs={allTabs} activeTabId="tab1" activeTab={tab1} />,
+    );
+    // tab1 should restore to 0.7
+    expect(screen.getByTestId('preview').getAttribute('data-scroll-fraction')).toBe('0.7');
+
+    // Switch back to tab2
+    rerender(
+      <AppContent {...createDefaultProps()} tabs={allTabs} activeTabId="tab2" activeTab={tab2} />,
+    );
+    // tab2 should restore to 0.3
+    expect(screen.getByTestId('preview').getAttribute('data-scroll-fraction')).toBe('0.3');
   });
 });


### PR DESCRIPTION
##   Summary

- Fixed an issue where the preview scroll position was reset when switching between tabs
- Manage per-tab scroll positions via a scrollFractionMap (Ref) and restore them on tab switch
- Added onScrollChange prop to Preview.tsx so preview-only mode (viewMode="preview") reports scroll events back to the parent
- Automatically clean up scroll position entries when tabs are closed
  Added tests: initial scroll position for new tabs (T-AC-11), scroll position restoration on tab switch (T-AC-12)