### PR TITLE
The tab names for unsaved files now display the text from the first line

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -16,6 +16,7 @@ import {
 import { Close, Add, PushPin } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { Tab as TabType } from '../types/tab';
+import { getTabDisplayTitle } from '../utils/pathUtils';
 import {
   DndContext,
   closestCenter,
@@ -180,7 +181,7 @@ const SortableTab: React.FC<{
                 minWidth: 0,
               }}
             >
-              {tab.title}
+              {getTabDisplayTitle(tab)}
             </Box>
             <Badge
               color="error"
@@ -263,7 +264,7 @@ const SortableTab: React.FC<{
                 minWidth: 0,
               }}
             >
-              {tab.title}
+              {getTabDisplayTitle(tab)}
             </Box>
             <Badge
               color="error"

--- a/src/utils/__tests__/pathUtils.test.ts
+++ b/src/utils/__tests__/pathUtils.test.ts
@@ -5,6 +5,7 @@ import {
   extractFolderNameFromPath,
   checkDuplicateFileInTabs,
   isMarkdownFile,
+  getTabDisplayTitle,
 } from '../pathUtils';
 import type { Tab } from '../../types/tab';
 
@@ -143,5 +144,54 @@ describe('isMarkdownFile', () => {
   it('T-PU-22: returns false for similar but non-markdown extensions', () => {
     expect(isMarkdownFile('file.mdx')).toBe(false);
     expect(isMarkdownFile('file.mdown')).toBe(false);
+  });
+});
+
+describe('getTabDisplayTitle', () => {
+  const makeTab = (overrides: Partial<Tab>): Tab => ({
+    id: 'test',
+    title: 'Untitled',
+    content: '',
+    isModified: false,
+    isNew: true,
+    ...overrides,
+  });
+
+  // T-PU-23
+  it('T-PU-23: returns file title for saved tabs', () => {
+    const tab = makeTab({ isNew: false, title: 'readme.md', content: '# Hello' });
+    expect(getTabDisplayTitle(tab)).toBe('readme.md');
+  });
+
+  // T-PU-24
+  it('T-PU-24: returns first line of content for new tabs', () => {
+    const tab = makeTab({ content: '# What\'s New\n\n- item1' });
+    expect(getTabDisplayTitle(tab)).toBe('# What\'s New');
+  });
+
+  // T-PU-25
+  it('T-PU-25: returns Untitled for new tabs with empty content', () => {
+    const tab = makeTab({ content: '' });
+    expect(getTabDisplayTitle(tab)).toBe('Untitled');
+  });
+
+  // T-PU-26
+  it('T-PU-26: truncates long first lines to 20 characters', () => {
+    const tab = makeTab({ content: 'This is a very long first line that should be truncated' });
+    const result = getTabDisplayTitle(tab);
+    expect(result).toBe('This is a very long …');
+    expect(result.length).toBe(21); // 20 chars + ellipsis
+  });
+
+  // T-PU-27
+  it('T-PU-27: returns Untitled when first line is whitespace only', () => {
+    const tab = makeTab({ content: '   \n\nsome content' });
+    expect(getTabDisplayTitle(tab)).toBe('Untitled');
+  });
+
+  // T-PU-28
+  it('T-PU-28: does not truncate exactly 20 character lines', () => {
+    const tab = makeTab({ content: '12345678901234567890' }); // exactly 20 chars
+    expect(getTabDisplayTitle(tab)).toBe('12345678901234567890');
   });
 });

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -41,3 +41,27 @@ export const isMarkdownFile = (fileName: string): boolean => {
   const lowerName = fileName.toLowerCase();
   return lowerName.endsWith('.md') || lowerName.endsWith('.markdown');
 };
+
+const UNTITLED_TAB_TITLE_MAX_LENGTH = 20;
+
+/**
+ * Get the display title for a tab.
+ * For unsaved (new) tabs, derives the title from the first line of content.
+ * Falls back to 'Untitled' if content is empty.
+ */
+export const getTabDisplayTitle = (tab: Tab): string => {
+  if (!tab.isNew) {
+    return tab.title;
+  }
+
+  const firstLine = tab.content.split('\n')[0]?.trim();
+  if (!firstLine) {
+    return 'Untitled';
+  }
+
+  if (firstLine.length > UNTITLED_TAB_TITLE_MAX_LENGTH) {
+    return firstLine.slice(0, UNTITLED_TAB_TITLE_MAX_LENGTH) + '…';
+  }
+
+  return firstLine;
+};


### PR DESCRIPTION
## Summary

Display the first line of file content as the tab title for unsaved tabs, instead of the generic "Untitled" label.
This helps users distinguish between multiple unsaved tabs at a glance. 
Empty tabs still fall back to "Untitled", and titles longer than 20 characters are truncated with an ellipsis.

## Changes

- Add getTabDisplayTitle() utility that derives tab display titles from the first line of content for unsaved (new) tabs, with 20-character truncation and "Untitled" fallback for
empty content
- Update TabBar component to use getTabDisplayTitle() for both vertical and horizontal tab layouts

## Tests

- Added 6 unit tests (T-PU-23 through T-PU-28) for getTabDisplayTitle() covering:
  - Saved tabs return their file name
  - New tabs return the first line of content
  - Empty new tabs fall back to "Untitled"
  - Long first lines are truncated to 20 characters with ellipsis
  - Whitespace-only first lines fall back to "Untitled"
  - Exactly 20-character lines are not truncated