### PR TITLE
Add scroll sync mode option for separate view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -427,6 +427,7 @@ function AppDesktop() {
             showWhitespace: appSettings.advanced.showWhitespace,
             tableConversion: appSettings.advanced.tableConversion,
           }}
+          scrollSyncMode={appSettings.interface.scrollSyncMode}
           outlineDisplayMode={appSettings.interface.outlineDisplayMode}
           outlinePanelOpen={outlinePanelOpen}
           onOutlinePanelClose={() => setOutlinePanelOpen(false)}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../hooks/useAppState', () => ({
         outlineDisplayMode: 'persistent',
         folderTreeDisplayMode: 'off',
         folderTreeFileFilter: 'markdown',
+        scrollSyncMode: 'editor-to-preview',
       },
       advanced: { autoSave: true, showWhitespace: false, tableConversion: 'confirm' },
       recentFiles: { maxRecentFiles: 20, showPreview: true, previewLength: 100 },

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -9,7 +9,7 @@ import EmptyState from './EmptyState';
 import { Tab } from '../types/tab';
 import { OutlineDisplayMode } from '../types/outline';
 import { FolderTreeDisplayMode, FolderTreeNode } from '../types/folderTree';
-import { RenderingSettings } from '../types/settings';
+import { RenderingSettings, ScrollSyncMode } from '../types/settings';
 import { useOutlineHeadings } from '../hooks/useOutlineHeadings';
 
 interface AppContentProps {
@@ -38,6 +38,9 @@ interface AppContentProps {
     showWhitespace: boolean;
     tableConversion: 'auto' | 'confirm' | 'off';
   };
+
+  // Scroll sync between editor and preview in split view
+  scrollSyncMode: ScrollSyncMode;
 
   // Outline
   outlineDisplayMode: OutlineDisplayMode;
@@ -96,6 +99,7 @@ const AppContent: React.FC<AppContentProps> = ({
   isSettingsLoaded,
   renderingSettings,
   editorSettings,
+  scrollSyncMode,
   outlineDisplayMode,
   outlinePanelOpen,
   onOutlinePanelClose,
@@ -135,7 +139,9 @@ const AppContent: React.FC<AppContentProps> = ({
   const scrollFractionMap = useRef<Map<string, number>>(new Map());
   const activeTabIdRef = useRef(activeTabId);
   activeTabIdRef.current = activeTabId;
-  const [scrollFraction, setScrollFraction] = useState(0);
+  // Track which side initiated the scroll so the originating side ignores its own update
+  // (prevents bidirectional sync from feedback-looping).
+  const [scrollState, setScrollState] = useState<{ fraction: number; source: 'editor' | 'preview' | 'restore' }>({ fraction: 0, source: 'restore' });
   const [revealLineRequest, setRevealLineRequest] = useState<{ lineNumber: number; requestId: number }>({ lineNumber: 0, requestId: 0 });
 
   const headings = useOutlineHeadings(activeTab?.content);
@@ -143,7 +149,7 @@ const AppContent: React.FC<AppContentProps> = ({
   // Restore scroll position when switching tabs
   useEffect(() => {
     if (activeTabId) {
-      setScrollFraction(scrollFractionMap.current.get(activeTabId) ?? 0);
+      setScrollState({ fraction: scrollFractionMap.current.get(activeTabId) ?? 0, source: 'restore' });
     }
   }, [activeTabId]);
 
@@ -160,12 +166,28 @@ const AppContent: React.FC<AppContentProps> = ({
   // Use ref for activeTabId to avoid stale closure in Editor's scroll listener.
   // Editor.tsx registers onScrollChange once at mount, so the callback reference must be stable.
   const handleEditorScrollChange = useCallback((fraction: number) => {
-    setScrollFraction(fraction);
+    setScrollState({ fraction, source: 'editor' });
     const tabId = activeTabIdRef.current;
     if (tabId) {
       scrollFractionMap.current.set(tabId, fraction);
     }
   }, []);
+
+  const handlePreviewScrollChange = useCallback((fraction: number) => {
+    setScrollState({ fraction, source: 'preview' });
+    const tabId = activeTabIdRef.current;
+    if (tabId) {
+      scrollFractionMap.current.set(tabId, fraction);
+    }
+  }, []);
+
+  // Per-side scroll value for split view: undefined means "do not push update to this side".
+  const editorScrollFraction = scrollSyncMode === 'bidirectional' && scrollState.source === 'preview'
+    ? scrollState.fraction
+    : undefined;
+  const previewSplitScrollFraction = scrollSyncMode !== 'off' && scrollState.source !== 'preview'
+    ? scrollState.fraction
+    : undefined;
 
   const handleHeadingClick = useCallback((lineNumber: number) => {
     setRevealLineRequest(prev => ({ lineNumber, requestId: prev.requestId + 1 }));
@@ -439,7 +461,8 @@ const AppContent: React.FC<AppContentProps> = ({
                       tableConversion={editorSettings?.tableConversion}
                       onSnackbar={onSnackbar}
                       onTableConversionSettingChange={onTableConversionSettingChange}
-                      onScrollChange={handleEditorScrollChange}
+                      onScrollChange={scrollSyncMode !== 'off' ? handleEditorScrollChange : undefined}
+                      scrollFraction={editorScrollFraction}
                       tabs={tabs}
                       activeTabId={activeTabId}
                       onTabSwitch={onTabChange}
@@ -461,7 +484,8 @@ const AppContent: React.FC<AppContentProps> = ({
                       globalVariables={globalVariables}
                       zoomLevel={currentZoom}
                       onContentChange={onContentChange}
-                      scrollFraction={scrollFraction}
+                      scrollFraction={previewSplitScrollFraction}
+                      onScrollChange={scrollSyncMode === 'bidirectional' ? handlePreviewScrollChange : undefined}
                       filePath={activeTab.filePath}
                       renderingSettings={renderingSettings}
                       viewMode="split"
@@ -514,8 +538,8 @@ const AppContent: React.FC<AppContentProps> = ({
                     onContentChange={onContentChange}
                     filePath={activeTab.filePath}
                     renderingSettings={renderingSettings}
-                    scrollFraction={scrollFraction}
-                    onScrollChange={handleEditorScrollChange}
+                    scrollFraction={scrollState.source !== 'preview' ? scrollState.fraction : undefined}
+                    onScrollChange={handlePreviewScrollChange}
                     viewMode="preview"
                   />
                 </Box>

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -39,6 +39,7 @@ interface EditorProps {
   onSnackbar?: (message: string, severity: 'success' | 'error' | 'warning') => void;
   onTableConversionSettingChange?: (newSetting: 'auto' | 'confirm' | 'off') => void;
   onScrollChange?: (scrollFraction: number) => void;
+  scrollFraction?: number;
   // Cross-tab search
   tabs?: Tab[];
   activeTabId?: string | null;
@@ -65,6 +66,7 @@ const MarkdownEditor: React.FC<EditorProps> = ({
   onSnackbar,
   onTableConversionSettingChange,
   onScrollChange,
+  scrollFraction,
   tabs,
   activeTabId,
   onTabSwitch,
@@ -85,6 +87,7 @@ const MarkdownEditor: React.FC<EditorProps> = ({
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const disposablesRef = useRef<import('monaco-editor').IDisposable[]>([]);
+  const isProgrammaticScrollRef = useRef(false);
 
   // Dispose Monaco listeners on unmount
   useEffect(() => {
@@ -385,6 +388,21 @@ const MarkdownEditor: React.FC<EditorProps> = ({
     }
   }, [focusRequestId, focusEditor]);
 
+  // Apply scroll position from parent (used in bidirectional sync mode)
+  useEffect(() => {
+    if (scrollFraction === undefined || !editorRef.current) return;
+    const editor = editorRef.current;
+    const maxScroll = editor.getScrollHeight() - editor.getLayoutInfo().height;
+    if (maxScroll <= 0) return;
+    const targetScroll = scrollFraction * maxScroll;
+    if (Math.abs(editor.getScrollTop() - targetScroll) < 1) return;
+    isProgrammaticScrollRef.current = true;
+    editor.setScrollTop(targetScroll);
+    requestAnimationFrame(() => {
+      isProgrammaticScrollRef.current = false;
+    });
+  }, [scrollFraction]);
+
   // Reveal line when revealLineRequest changes (outline panel heading click)
   useEffect(() => {
     if (!revealLineRequest || revealLineRequest.requestId === 0) return;
@@ -502,6 +520,8 @@ const MarkdownEditor: React.FC<EditorProps> = ({
     if (onScrollChange) {
       disposablesRef.current.push(
         editor.onDidScrollChange(() => {
+          // Skip events triggered by our own programmatic scroll to avoid feedback loops
+          if (isProgrammaticScrollRef.current) return;
           const scrollTop = editor.getScrollTop();
           const scrollHeight = editor.getScrollHeight();
           const clientHeight = editor.getLayoutInfo().height;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -48,6 +48,7 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
   const isMarp = renderingSettings.enableMarp && contentIsMarp(content);
   const previewRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isProgrammaticScrollRef = useRef(false);
   const [processedContent, setProcessedContent] = useState(content || '');
   const [htmlContent, setHtmlContent] = useState<string>('');
   const [exportError, setExportError] = useState<string | null>(null);
@@ -304,20 +305,26 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
 
   // Sync scroll from editor
   useEffect(() => {
-    if (scrollFraction !== undefined && scrollContainerRef.current) {
-      const container = scrollContainerRef.current;
-      const maxScroll = container.scrollHeight - container.clientHeight;
-      if (maxScroll > 0) {
-        container.scrollTop = scrollFraction * maxScroll;
-      }
-    }
+    if (scrollFraction === undefined || !scrollContainerRef.current) return;
+    const container = scrollContainerRef.current;
+    const maxScroll = container.scrollHeight - container.clientHeight;
+    if (maxScroll <= 0) return;
+    const targetScroll = scrollFraction * maxScroll;
+    if (Math.abs(container.scrollTop - targetScroll) < 1) return;
+    isProgrammaticScrollRef.current = true;
+    container.scrollTop = targetScroll;
+    requestAnimationFrame(() => {
+      isProgrammaticScrollRef.current = false;
+    });
   }, [scrollFraction]);
 
-  // Report scroll position back to parent (used in preview-only mode)
+  // Report scroll position back to parent
   useEffect(() => {
     if (!onScrollChange || !scrollContainerRef.current) return;
     const container = scrollContainerRef.current;
     const handleScroll = () => {
+      // Skip events triggered by our own programmatic scroll to avoid feedback loops
+      if (isProgrammaticScrollRef.current) return;
       const maxScroll = container.scrollHeight - container.clientHeight;
       if (maxScroll > 0) {
         onScrollChange(container.scrollTop / maxScroll);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -815,6 +815,67 @@ const Settings: React.FC<SettingsProps> = ({
                     </FormControl>
                   </CardContent>
                 </Card>
+
+                {/* Scroll Sync Mode */}
+                <Card sx={{ mt: 3 }}>
+                  <CardContent>
+                    <Typography variant="h6" sx={{ mb: 1 }}>
+                      {t('settings.interface.scrollSyncMode')}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                      {t('settings.interface.scrollSyncModeDescription')}
+                    </Typography>
+                    <FormControl component="fieldset">
+                      <RadioGroup
+                        value={settings.interface.scrollSyncMode}
+                        onChange={(e) => handleSettingChange('interface', 'scrollSyncMode', e.target.value)}
+                      >
+                        <FormControlLabel
+                          value="editor-to-preview"
+                          control={<Radio />}
+                          label={
+                            <Box>
+                              <Typography variant="body1">
+                                {t('settings.interface.scrollSyncModeEditorToPreview')}
+                              </Typography>
+                              <Typography variant="body2" color="text.secondary">
+                                {t('settings.interface.scrollSyncModeEditorToPreviewDescription')}
+                              </Typography>
+                            </Box>
+                          }
+                        />
+                        <FormControlLabel
+                          value="bidirectional"
+                          control={<Radio />}
+                          label={
+                            <Box>
+                              <Typography variant="body1">
+                                {t('settings.interface.scrollSyncModeBidirectional')}
+                              </Typography>
+                              <Typography variant="body2" color="text.secondary">
+                                {t('settings.interface.scrollSyncModeBidirectionalDescription')}
+                              </Typography>
+                            </Box>
+                          }
+                        />
+                        <FormControlLabel
+                          value="off"
+                          control={<Radio />}
+                          label={
+                            <Box>
+                              <Typography variant="body1">
+                                {t('settings.interface.scrollSyncModeOff')}
+                              </Typography>
+                              <Typography variant="body2" color="text.secondary">
+                                {t('settings.interface.scrollSyncModeOffDescription')}
+                              </Typography>
+                            </Box>
+                          }
+                        />
+                      </RadioGroup>
+                    </FormControl>
+                  </CardContent>
+                </Card>
               </Box>
             )}
 

--- a/src/components/__tests__/AppContent.test.tsx
+++ b/src/components/__tests__/AppContent.test.tsx
@@ -57,6 +57,7 @@ const createDefaultProps = () => ({
   currentZoom: 1.0,
   isInitialized: true,
   isSettingsLoaded: true,
+  scrollSyncMode: 'editor-to-preview' as const,
   outlineDisplayMode: 'persistent' as const,
   outlinePanelOpen: false,
   onOutlinePanelClose: vi.fn(),

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "فلتر ملفات المستكشف",
       "folderTreeFileFilterDescription": "اختر الملفات المراد عرضها في المستكشف.",
       "folderTreeFileFilterMarkdown": "ملفات Markdown فقط (.md, .txt)",
-      "folderTreeFileFilterAll": "جميع الملفات"
+      "folderTreeFileFilterAll": "جميع الملفات",
+      "scrollSyncMode": "مزامنة التمرير (العرض المنقسم)",
+      "scrollSyncModeDescription": "اختر كيفية تمرير لوحتي المحرر والمعاينة معًا في العرض المنقسم.",
+      "scrollSyncModeEditorToPreview": "المحرر ← المعاينة",
+      "scrollSyncModeEditorToPreviewDescription": "تمرير المحرر يمرر المعاينة. تمرير المعاينة لا يحرك المحرر.",
+      "scrollSyncModeBidirectional": "ثنائي الاتجاه",
+      "scrollSyncModeBidirectionalDescription": "تمرير أي من اللوحتين يمرر الأخرى بشكل متزامن.",
+      "scrollSyncModeOff": "معطل",
+      "scrollSyncModeOffDescription": "كل لوحة تتمرر بشكل مستقل."
     },
     "advanced": {
       "title": "متقدم",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Explorer-Dateifilter",
       "folderTreeFileFilterDescription": "Wählen Sie, welche Dateien im Explorer angezeigt werden.",
       "folderTreeFileFilterMarkdown": "Nur Markdown-Dateien (.md, .txt)",
-      "folderTreeFileFilterAll": "Alle Dateien"
+      "folderTreeFileFilterAll": "Alle Dateien",
+      "scrollSyncMode": "Scroll-Synchronisierung (Geteilte Ansicht)",
+      "scrollSyncModeDescription": "Wählen Sie, wie Editor- und Vorschaubereich in der geteilten Ansicht gemeinsam scrollen.",
+      "scrollSyncModeEditorToPreview": "Editor → Vorschau",
+      "scrollSyncModeEditorToPreviewDescription": "Beim Scrollen des Editors wird die Vorschau mitgescrollt. Das Scrollen der Vorschau bewegt den Editor nicht.",
+      "scrollSyncModeBidirectional": "Bidirektional",
+      "scrollSyncModeBidirectionalDescription": "Das Scrollen eines Bereichs scrollt den anderen synchron mit.",
+      "scrollSyncModeOff": "Aus",
+      "scrollSyncModeOffDescription": "Jeder Bereich scrollt unabhängig."
     },
     "advanced": {
       "title": "Erweitert",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Explorer File Filter",
       "folderTreeFileFilterDescription": "Choose which files to display in the explorer.",
       "folderTreeFileFilterMarkdown": "Markdown files only (.md, .txt)",
-      "folderTreeFileFilterAll": "All files"
+      "folderTreeFileFilterAll": "All files",
+      "scrollSyncMode": "Scroll Sync (Split view)",
+      "scrollSyncModeDescription": "Choose how the editor and preview panes scroll together in split view.",
+      "scrollSyncModeEditorToPreview": "Editor → Preview",
+      "scrollSyncModeEditorToPreviewDescription": "Scrolling the editor scrolls the preview. Scrolling the preview does not move the editor.",
+      "scrollSyncModeBidirectional": "Bidirectional",
+      "scrollSyncModeBidirectionalDescription": "Scrolling either pane scrolls the other in sync.",
+      "scrollSyncModeOff": "Off",
+      "scrollSyncModeOffDescription": "Each pane scrolls independently."
     },
     "advanced": {
       "title": "Advanced",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Filtro de archivos del explorador",
       "folderTreeFileFilterDescription": "Elija qué archivos mostrar en el explorador.",
       "folderTreeFileFilterMarkdown": "Solo archivos Markdown (.md, .txt)",
-      "folderTreeFileFilterAll": "Todos los archivos"
+      "folderTreeFileFilterAll": "Todos los archivos",
+      "scrollSyncMode": "Sincronización de desplazamiento (Vista dividida)",
+      "scrollSyncModeDescription": "Elija cómo se desplazan juntos los paneles del editor y la vista previa en la vista dividida.",
+      "scrollSyncModeEditorToPreview": "Editor → Vista previa",
+      "scrollSyncModeEditorToPreviewDescription": "Al desplazarse en el editor, también se desplaza la vista previa. Desplazar la vista previa no mueve el editor.",
+      "scrollSyncModeBidirectional": "Bidireccional",
+      "scrollSyncModeBidirectionalDescription": "Al desplazarse en cualquiera de los paneles, el otro se desplaza en sincronía.",
+      "scrollSyncModeOff": "Desactivado",
+      "scrollSyncModeOffDescription": "Cada panel se desplaza de forma independiente."
     },
     "advanced": {
       "title": "Avanzado",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Filtre de fichiers de l'explorateur",
       "folderTreeFileFilterDescription": "Choisissez quels fichiers afficher dans l'explorateur.",
       "folderTreeFileFilterMarkdown": "Fichiers Markdown uniquement (.md, .txt)",
-      "folderTreeFileFilterAll": "Tous les fichiers"
+      "folderTreeFileFilterAll": "Tous les fichiers",
+      "scrollSyncMode": "Synchronisation du défilement (Vue divisée)",
+      "scrollSyncModeDescription": "Choisissez comment les volets éditeur et aperçu défilent ensemble en vue divisée.",
+      "scrollSyncModeEditorToPreview": "Éditeur → Aperçu",
+      "scrollSyncModeEditorToPreviewDescription": "Faire défiler l'éditeur fait défiler l'aperçu. Faire défiler l'aperçu ne déplace pas l'éditeur.",
+      "scrollSyncModeBidirectional": "Bidirectionnel",
+      "scrollSyncModeBidirectionalDescription": "Faire défiler un volet fait défiler l'autre en synchronisation.",
+      "scrollSyncModeOff": "Désactivé",
+      "scrollSyncModeOffDescription": "Chaque volet défile indépendamment."
     },
     "advanced": {
       "title": "Avancé",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "एक्सप्लोरर फ़ाइल फ़िल्टर",
       "folderTreeFileFilterDescription": "एक्सप्लोरर में कौन सी फ़ाइलें प्रदर्शित करनी हैं, चुनें।",
       "folderTreeFileFilterMarkdown": "केवल Markdown फ़ाइलें (.md, .txt)",
-      "folderTreeFileFilterAll": "सभी फ़ाइलें"
+      "folderTreeFileFilterAll": "सभी फ़ाइलें",
+      "scrollSyncMode": "स्क्रॉल सिंक (विभाजित दृश्य)",
+      "scrollSyncModeDescription": "विभाजित दृश्य में एडिटर और प्रीव्यू पैनल कैसे एक साथ स्क्रॉल करें यह चुनें।",
+      "scrollSyncModeEditorToPreview": "एडिटर → प्रीव्यू",
+      "scrollSyncModeEditorToPreviewDescription": "एडिटर को स्क्रॉल करने पर प्रीव्यू भी स्क्रॉल होती है। प्रीव्यू को स्क्रॉल करने से एडिटर नहीं हिलता।",
+      "scrollSyncModeBidirectional": "द्विदिशीय",
+      "scrollSyncModeBidirectionalDescription": "किसी भी पैनल को स्क्रॉल करने पर दूसरा पैनल भी सिंक में स्क्रॉल होता है।",
+      "scrollSyncModeOff": "बंद",
+      "scrollSyncModeOffDescription": "प्रत्येक पैनल स्वतंत्र रूप से स्क्रॉल होता है।"
     },
     "advanced": {
       "title": "उन्नत",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Filter File Explorer",
       "folderTreeFileFilterDescription": "Pilih file mana yang ditampilkan di explorer.",
       "folderTreeFileFilterMarkdown": "Hanya file Markdown (.md, .txt)",
-      "folderTreeFileFilterAll": "Semua file"
+      "folderTreeFileFilterAll": "Semua file",
+      "scrollSyncMode": "Sinkronisasi Gulir (Tampilan terbagi)",
+      "scrollSyncModeDescription": "Pilih cara panel editor dan pratinjau bergulir bersama dalam tampilan terbagi.",
+      "scrollSyncModeEditorToPreview": "Editor → Pratinjau",
+      "scrollSyncModeEditorToPreviewDescription": "Menggulir editor akan menggulir pratinjau. Menggulir pratinjau tidak menggerakkan editor.",
+      "scrollSyncModeBidirectional": "Dua arah",
+      "scrollSyncModeBidirectionalDescription": "Menggulir salah satu panel akan menggulir panel lainnya secara sinkron.",
+      "scrollSyncModeOff": "Mati",
+      "scrollSyncModeOffDescription": "Setiap panel bergulir secara independen."
     },
     "advanced": {
       "title": "Lanjutan",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "エクスプローラーファイルフィルター",
       "folderTreeFileFilterDescription": "エクスプローラーに表示するファイルの種類を選択してください。",
       "folderTreeFileFilterMarkdown": "Markdownファイルのみ (.md, .txt)",
-      "folderTreeFileFilterAll": "すべてのファイル"
+      "folderTreeFileFilterAll": "すべてのファイル",
+      "scrollSyncMode": "スクロール同期 (分割モード)",
+      "scrollSyncModeDescription": "分割モードでエディターとプレビューのスクロールを同期する方法を選択します。",
+      "scrollSyncModeEditorToPreview": "エディター → プレビュー",
+      "scrollSyncModeEditorToPreviewDescription": "エディターをスクロールするとプレビューも同期します。プレビューをスクロールしてもエディターは動きません。",
+      "scrollSyncModeBidirectional": "双方向",
+      "scrollSyncModeBidirectionalDescription": "どちらをスクロールしても、もう片方も同期してスクロールします。",
+      "scrollSyncModeOff": "オフ",
+      "scrollSyncModeOffDescription": "エディターとプレビューはそれぞれ独立してスクロールします。"
     },
     "advanced": {
       "title": "高度な設定",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "탐색기 파일 필터",
       "folderTreeFileFilterDescription": "탐색기에 표시할 파일을 선택합니다.",
       "folderTreeFileFilterMarkdown": "Markdown 파일만 (.md, .txt)",
-      "folderTreeFileFilterAll": "모든 파일"
+      "folderTreeFileFilterAll": "모든 파일",
+      "scrollSyncMode": "스크롤 동기화 (분할 보기)",
+      "scrollSyncModeDescription": "분할 보기에서 에디터와 미리보기 창이 함께 스크롤되는 방식을 선택하세요.",
+      "scrollSyncModeEditorToPreview": "에디터 → 미리보기",
+      "scrollSyncModeEditorToPreviewDescription": "에디터를 스크롤하면 미리보기도 스크롤됩니다. 미리보기를 스크롤해도 에디터는 움직이지 않습니다.",
+      "scrollSyncModeBidirectional": "양방향",
+      "scrollSyncModeBidirectionalDescription": "어느 쪽을 스크롤해도 다른 쪽이 동기화되어 스크롤됩니다.",
+      "scrollSyncModeOff": "끄기",
+      "scrollSyncModeOffDescription": "각 창이 독립적으로 스크롤됩니다."
     },
     "advanced": {
       "title": "고급",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Filtro de arquivos do explorador",
       "folderTreeFileFilterDescription": "Escolha quais arquivos exibir no explorador.",
       "folderTreeFileFilterMarkdown": "Somente arquivos Markdown (.md, .txt)",
-      "folderTreeFileFilterAll": "Todos os arquivos"
+      "folderTreeFileFilterAll": "Todos os arquivos",
+      "scrollSyncMode": "Sincronização de rolagem (Visão dividida)",
+      "scrollSyncModeDescription": "Escolha como os painéis do editor e da pré-visualização rolam juntos na visão dividida.",
+      "scrollSyncModeEditorToPreview": "Editor → Pré-visualização",
+      "scrollSyncModeEditorToPreviewDescription": "Rolar o editor rola a pré-visualização. Rolar a pré-visualização não move o editor.",
+      "scrollSyncModeBidirectional": "Bidirecional",
+      "scrollSyncModeBidirectionalDescription": "Rolar qualquer painel rola o outro em sincronia.",
+      "scrollSyncModeOff": "Desativado",
+      "scrollSyncModeOffDescription": "Cada painel rola de forma independente."
     },
     "advanced": {
       "title": "Avançado",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Фильтр файлов проводника",
       "folderTreeFileFilterDescription": "Выберите, какие файлы отображать в проводнике.",
       "folderTreeFileFilterMarkdown": "Только файлы Markdown (.md, .txt)",
-      "folderTreeFileFilterAll": "Все файлы"
+      "folderTreeFileFilterAll": "Все файлы",
+      "scrollSyncMode": "Синхронизация прокрутки (разделённый вид)",
+      "scrollSyncModeDescription": "Выберите, как панели редактора и предпросмотра прокручиваются вместе в разделённом виде.",
+      "scrollSyncModeEditorToPreview": "Редактор → Предпросмотр",
+      "scrollSyncModeEditorToPreviewDescription": "Прокрутка редактора прокручивает предпросмотр. Прокрутка предпросмотра не двигает редактор.",
+      "scrollSyncModeBidirectional": "Двунаправленная",
+      "scrollSyncModeBidirectionalDescription": "Прокрутка любой панели синхронно прокручивает другую.",
+      "scrollSyncModeOff": "Отключено",
+      "scrollSyncModeOffDescription": "Каждая панель прокручивается независимо."
     },
     "advanced": {
       "title": "Дополнительно",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "Bộ lọc tệp Explorer",
       "folderTreeFileFilterDescription": "Chọn tệp nào để hiển thị trong explorer.",
       "folderTreeFileFilterMarkdown": "Chỉ tệp Markdown (.md, .txt)",
-      "folderTreeFileFilterAll": "Tất cả tệp"
+      "folderTreeFileFilterAll": "Tất cả tệp",
+      "scrollSyncMode": "Đồng bộ cuộn (Chế độ chia đôi)",
+      "scrollSyncModeDescription": "Chọn cách trình soạn thảo và bảng xem trước cuộn cùng nhau trong chế độ chia đôi.",
+      "scrollSyncModeEditorToPreview": "Trình soạn thảo → Xem trước",
+      "scrollSyncModeEditorToPreviewDescription": "Cuộn trình soạn thảo sẽ cuộn xem trước. Cuộn xem trước không di chuyển trình soạn thảo.",
+      "scrollSyncModeBidirectional": "Hai chiều",
+      "scrollSyncModeBidirectionalDescription": "Cuộn ở một bảng sẽ đồng bộ cuộn bảng còn lại.",
+      "scrollSyncModeOff": "Tắt",
+      "scrollSyncModeOffDescription": "Mỗi bảng cuộn độc lập."
     },
     "advanced": {
       "title": "Nâng cao",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "资源管理器文件过滤器",
       "folderTreeFileFilterDescription": "选择在资源管理器中显示哪些文件。",
       "folderTreeFileFilterMarkdown": "仅 Markdown 文件 (.md, .txt)",
-      "folderTreeFileFilterAll": "所有文件"
+      "folderTreeFileFilterAll": "所有文件",
+      "scrollSyncMode": "滚动同步（分屏视图）",
+      "scrollSyncModeDescription": "选择分屏视图中编辑器与预览面板的滚动同步方式。",
+      "scrollSyncModeEditorToPreview": "编辑器 → 预览",
+      "scrollSyncModeEditorToPreviewDescription": "滚动编辑器时预览也会滚动。滚动预览不会移动编辑器。",
+      "scrollSyncModeBidirectional": "双向",
+      "scrollSyncModeBidirectionalDescription": "滚动任一面板，另一面板都会同步滚动。",
+      "scrollSyncModeOff": "关闭",
+      "scrollSyncModeOffDescription": "两个面板各自独立滚动。"
     },
     "advanced": {
       "title": "高级",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -358,7 +358,15 @@
       "folderTreeFileFilter": "檔案總管檔案篩選器",
       "folderTreeFileFilterDescription": "選擇在檔案總管中顯示哪些檔案。",
       "folderTreeFileFilterMarkdown": "僅 Markdown 檔案 (.md, .txt)",
-      "folderTreeFileFilterAll": "所有檔案"
+      "folderTreeFileFilterAll": "所有檔案",
+      "scrollSyncMode": "捲動同步（分割檢視）",
+      "scrollSyncModeDescription": "選擇在分割檢視中編輯器與預覽面板如何同步捲動。",
+      "scrollSyncModeEditorToPreview": "編輯器 → 預覽",
+      "scrollSyncModeEditorToPreviewDescription": "捲動編輯器時預覽也會捲動。捲動預覽不會移動編輯器。",
+      "scrollSyncModeBidirectional": "雙向",
+      "scrollSyncModeBidirectionalDescription": "捲動任一面板，另一面板都會同步捲動。",
+      "scrollSyncModeOff": "關閉",
+      "scrollSyncModeOffDescription": "兩個面板各自獨立捲動。"
     },
     "advanced": {
       "title": "進階",

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,6 +1,8 @@
 import { OutlineDisplayMode } from './outline';
 import { FolderTreeDisplayMode } from './folderTree';
 
+export type ScrollSyncMode = 'editor-to-preview' | 'bidirectional' | 'off';
+
 // Editor settings type definition
 export interface EditorSettings {
   fontSize: number;
@@ -25,6 +27,7 @@ export interface InterfaceSettings {
   outlineDisplayMode: OutlineDisplayMode;
   folderTreeDisplayMode: FolderTreeDisplayMode;
   folderTreeFileFilter: 'markdown' | 'all';
+  scrollSyncMode: ScrollSyncMode;
 }
 
 // Rendering settings type definition
@@ -81,6 +84,7 @@ export const DEFAULT_INTERFACE_SETTINGS: InterfaceSettings = {
   outlineDisplayMode: 'persistent',
   folderTreeDisplayMode: 'off',
   folderTreeFileFilter: 'markdown',
+  scrollSyncMode: 'editor-to-preview',
 };
 
 export const DEFAULT_ADVANCED_SETTINGS: AdvancedSettings = {


### PR DESCRIPTION
## Summary

Adds a user-configurable scroll synchronization mode for the split view, exposed in Settings → Interface. Users can now choose between editor-to-preview only (current behavior,
default), bidirectional sync, or no sync, replacing the previously hardcoded one-way behavior.

## Changes

- Added `ScrollSyncMode` type (`'editor-to-preview' | 'bidirectional' | 'off'`) and `scrollSyncMode` field to `InterfaceSettings`, defaulting to `'editor-to-preview'` so existing
users keep current behavior.
- Added a Scroll Sync card with a 3-option RadioGroup to the Interface tab in the Settings dialog.
- Refactored `AppContent` scroll state to track which side initiated the scroll (`{ fraction, source }`), and conditionally pass `scrollFraction` / `onScrollChange` to Editor and
Preview based on the selected mode.
- Extended `Editor` to accept a `scrollFraction` prop and apply it programmatically to Monaco, with a `isProgrammaticScrollRef` guard to suppress the resulting `onDidScrollChange`
event and prevent feedback loops.
- Added the same programmatic-scroll guard to `Preview` so bidirectional sync no longer ping-pongs between the two panes.
- Added translations for the new setting (label, description, and three option labels with descriptions) across all 14 supported locales.

## Tests

Updated `src/__tests__/App.test.tsx` and `src/components/__tests__/AppContent.test.tsx` mocks to include the new `scrollSyncMode` field. No new test cases were added.