### PR TITLE
Implementing Refactoring

### DIFF
--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -11,6 +11,8 @@ import { OutlineDisplayMode } from '../types/outline';
 import { FolderTreeDisplayMode, FolderTreeNode } from '../types/folderTree';
 import { RenderingSettings, ScrollSyncMode } from '../types/settings';
 import { useOutlineHeadings } from '../hooks/useOutlineHeadings';
+import { useResizableSidebar } from '../hooks/useResizableSidebar';
+import { DRAWER_WIDTH_PX, LAYOUT_SETTLE_DELAY_MS, SIDEBAR_DIVIDER_HEIGHT_PX, SIDEBAR_WIDTH_PX } from '../constants/layout';
 
 interface AppContentProps {
   // State
@@ -207,74 +209,20 @@ const AppContent: React.FC<AppContentProps> = ({
   const showStandaloneVerticalTabs = tabLayout === 'vertical' && !showMergedLeftSidebar;
 
   // Resizable divider state for merged sidebar
-  const [tabSectionHeight, setTabSectionHeight] = useState(200);
-  const [explorerCollapsed, setExplorerCollapsed] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
-  const explorerHeightBeforeCollapse = useRef(0);
-  const isDraggingRef = useRef(false);
-  const sidebarRef = useRef<HTMLDivElement>(null);
-
-  const handleExplorerHeaderClick = useCallback(() => {
-    if (explorerCollapsed) {
-      // Restore previous height (or default)
-      const restoreH = explorerHeightBeforeCollapse.current || 200;
-      if (sidebarRef.current) {
-        const maxH = sidebarRef.current.getBoundingClientRect().height - 120;
-        setTabSectionHeight(Math.min(restoreH, maxH));
-      } else {
-        setTabSectionHeight(restoreH);
-      }
-      setExplorerCollapsed(false);
-    } else {
-      // Save current height then collapse explorer (body hidden, header stays)
-      explorerHeightBeforeCollapse.current = tabSectionHeight;
-      // Set tab section to fill, leaving room for explorer header + divider
-      if (sidebarRef.current) {
-        const totalH = sidebarRef.current.getBoundingClientRect().height;
-        setTabSectionHeight(totalH - 48);
-      }
-      setExplorerCollapsed(true);
-    }
-  }, [explorerCollapsed, tabSectionHeight]);
-
-  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    isDraggingRef.current = true;
-    setIsDragging(true);
-
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!isDraggingRef.current || !sidebarRef.current) return;
-      const sidebarRect = sidebarRef.current.getBoundingClientRect();
-      const newHeight = ev.clientY - sidebarRect.top;
-      const minH = 80;
-      // Explorer header (~40px) + divider (4px) = 44px must always remain
-      const maxH = sidebarRect.height - 48;
-      const clamped = Math.max(minH, Math.min(maxH, newHeight));
-      setTabSectionHeight(clamped);
-      // Un-collapse when user drags to give explorer more space
-      setExplorerCollapsed(false);
-    };
-
-    const onMouseUp = () => {
-      isDraggingRef.current = false;
-      setIsDragging(false);
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.body.style.cursor = 'row-resize';
-    document.body.style.userSelect = 'none';
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, []);
+  const {
+    sidebarRef,
+    topSectionHeight: tabSectionHeight,
+    bottomCollapsed: explorerCollapsed,
+    isDragging,
+    toggleBottomCollapsed: handleExplorerHeaderClick,
+    handleDividerMouseDown,
+  } = useResizableSidebar();
 
   // Force Monaco Editor to recalculate layout when persistent panels toggle
   useEffect(() => {
     const timer = setTimeout(() => {
       window.dispatchEvent(new Event('resize'));
-    }, 50);
+    }, LAYOUT_SETTLE_DELAY_MS);
     return () => clearTimeout(timer);
   }, [outlinePanelOpen, outlineDisplayMode, folderTreePanelOpen, folderTreeDisplayMode]);
 
@@ -285,8 +233,8 @@ const AppContent: React.FC<AppContentProps> = ({
         <Box
           ref={sidebarRef}
           sx={{
-            width: 280,
-            minWidth: 280,
+            width: SIDEBAR_WIDTH_PX,
+            minWidth: SIDEBAR_WIDTH_PX,
             display: 'flex',
             flexDirection: 'column',
             height: '100%',
@@ -326,7 +274,7 @@ const AppContent: React.FC<AppContentProps> = ({
           <Box
             onMouseDown={handleDividerMouseDown}
             sx={{
-              height: 4,
+              height: SIDEBAR_DIVIDER_HEIGHT_PX,
               cursor: 'row-resize',
               flexShrink: 0,
               bgcolor: 'divider',
@@ -353,7 +301,7 @@ const AppContent: React.FC<AppContentProps> = ({
               onClose={onFolderTreePanelClose}
               onHeaderClick={handleExplorerHeaderClick}
               collapsed={explorerCollapsed}
-              width={280}
+              width={SIDEBAR_WIDTH_PX}
               onRenameRequest={onRenameRequest}
             />
           </Box>
@@ -560,13 +508,13 @@ const AppContent: React.FC<AppContentProps> = ({
                   variant="temporary"
                   open={outlinePanelOpen}
                   onClose={onOutlinePanelClose}
-                  PaperProps={{ sx: { width: 280 } }}
+                  PaperProps={{ sx: { width: DRAWER_WIDTH_PX } }}
                 >
                   <OutlinePanel
                     headings={headings}
                     onHeadingClick={handleHeadingClick}
                     onClose={onOutlinePanelClose}
-                    width={280}
+                    width={DRAWER_WIDTH_PX}
                   />
                 </Drawer>
               )}
@@ -582,7 +530,7 @@ const AppContent: React.FC<AppContentProps> = ({
           variant="temporary"
           open={folderTreePanelOpen}
           onClose={onFolderTreePanelClose}
-          PaperProps={{ sx: { width: 280 } }}
+          PaperProps={{ sx: { width: DRAWER_WIDTH_PX } }}
         >
           <FolderTreePanel
             rootFolderName={folderTreeRootFolderName}
@@ -598,7 +546,7 @@ const AppContent: React.FC<AppContentProps> = ({
             onCloseFolder={onFolderTreeCloseFolder}
             onRefresh={onFolderTreeRefresh}
             onClose={onFolderTreePanelClose}
-            width={280}
+            width={DRAWER_WIDTH_PX}
             onRenameRequest={onRenameRequest}
           />
         </Drawer>

--- a/src/components/MarpPreview.tsx
+++ b/src/components/MarpPreview.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Box, Typography, IconButton, Tooltip } from '@mui/material';
 import { NavigateBefore, NavigateNext, Fullscreen, FullscreenExit, GridView } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
-import { readFile } from '@tauri-apps/plugin-fs';
 import { variableApi } from '../api/variableApi';
 import { renderMarp, buildSlideDocument, buildAllSlidesDocument, buildThumbnailDocument } from '../utils/marpRenderer';
+import { inlineMarpRelativeImages } from '../utils/marpImageInliner';
+import { computeSlideLineRanges, scrollFractionToSlidePosition } from '../utils/marpSlideRanges';
 
 interface MarpPreviewProps {
   content: string;
@@ -17,143 +18,9 @@ interface MarpPreviewProps {
   viewMode?: 'split' | 'editor' | 'preview';
 }
 
-/** Resolve a relative path against a base directory path */
-function resolveRelativePath(baseDirPath: string, relativePath: string): string {
-  const parts = (baseDirPath + '/' + relativePath).split('/').filter(Boolean);
-  const resolved: string[] = [];
-  for (const part of parts) {
-    if (part === '.') continue;
-    if (part === '..') {
-      resolved.pop();
-    } else {
-      resolved.push(part);
-    }
-  }
-  return '/' + resolved.join('/');
-}
-
-const MIME_MAP: Record<string, string> = {
-  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
-  gif: 'image/gif', svg: 'image/svg+xml', webp: 'image/webp',
-  bmp: 'image/bmp', ico: 'image/x-icon', avif: 'image/avif',
-};
-
-/** Check if a URL is absolute (http, https, data, blob) */
-function isAbsoluteUrl(src: string): boolean {
-  return src.startsWith('http://') || src.startsWith('https://') || src.startsWith('data:') || src.startsWith('blob:');
-}
-
-/** Read a local file and return its data URL */
-async function readAsDataUrl(absolutePath: string, src: string): Promise<string> {
-  const data = await readFile(absolutePath);
-  const ext = src.split('.').pop()?.toLowerCase() || '';
-  const mime = MIME_MAP[ext] || 'application/octet-stream';
-  let binary = '';
-  for (let i = 0; i < data.length; i++) {
-    binary += String.fromCharCode(data[i]);
-  }
-  return `data:${mime};base64,${btoa(binary)}`;
-}
-
-/**
- * Replace relative image references in HTML with inline data URLs.
- * Handles:
- * - <img src="..."> tags (regular images)
- * - CSS url("...") patterns (Marp background images)
- * - <image href="..."> / <image xlink:href="..."> SVG elements
- */
-async function inlineRelativeImages(html: string, filePath: string): Promise<string> {
-  const baseDir = filePath.substring(0, filePath.lastIndexOf('/'));
-  const replacements = new Map<string, string>();
-  const promises: Promise<void>[] = [];
-
-  /** Collect a src for replacement if it's a relative path */
-  function collectSrc(src: string) {
-    if (isAbsoluteUrl(src) || replacements.has(src)) return;
-    replacements.set(src, src); // reserve
-    const absolutePath = resolveRelativePath(baseDir, src);
-    promises.push(
-      readAsDataUrl(absolutePath, src)
-        .then(dataUrl => { replacements.set(src, dataUrl); })
-        .catch(err => { console.error('[MarpPreview] Failed to inline image:', absolutePath, err); })
-    );
-  }
-
-  // 1. <img src="...">
-  const imgRegex = /<img\s+[^>]*?src="([^"]+)"[^>]*?>/g;
-  let match;
-  while ((match = imgRegex.exec(html)) !== null) {
-    collectSrc(match[1]);
-  }
-
-  // 2. CSS url(&quot;...&quot;) — Marp encodes quotes as HTML entities in inline styles
-  const urlEntityRegex = /url\(&quot;([^&]+)&quot;\)/g;
-  while ((match = urlEntityRegex.exec(html)) !== null) {
-    collectSrc(match[1]);
-  }
-
-  // 3. CSS url("...") — fallback for unencoded quotes
-  const urlRegex = /url\("([^"]+)"\)/g;
-  while ((match = urlRegex.exec(html)) !== null) {
-    collectSrc(match[1]);
-  }
-
-  // 4. SVG <image href="..."> or <image xlink:href="...">
-  const imageHrefRegex = /<image\s+[^>]*?(?:xlink:)?href="([^"]+)"[^>]*?>/g;
-  while ((match = imageHrefRegex.exec(html)) !== null) {
-    collectSrc(match[1]);
-  }
-
-  await Promise.all(promises);
-
-  let result = html;
-  for (const [original, dataUrl] of replacements) {
-    if (dataUrl !== original) {
-      result = result.split(`src="${original}"`).join(`src="${dataUrl}"`);
-      result = result.split(`url(&quot;${original}&quot;)`).join(`url(&quot;${dataUrl}&quot;)`);
-      result = result.split(`url("${original}")`).join(`url("${dataUrl}")`);
-      result = result.split(`href="${original}"`).join(`href="${dataUrl}"`);
-    }
-  }
-  return result;
-}
-
-/**
- * Compute the line ranges for each Marp slide from the source content.
- * Returns an array of { startLine, endLine } (0-based, inclusive).
- * The frontmatter block (first --- ... ---) is treated as part of slide 0.
- */
-function computeSlideLineRanges(content: string): { startLine: number; endLine: number }[] {
-  const lines = content.split('\n');
-  const totalLines = lines.length;
-
-  // Find frontmatter end (second ---)
-  let contentStart = 0;
-  if (lines[0]?.trim() === '---') {
-    for (let i = 1; i < totalLines; i++) {
-      if (lines[i]?.trim() === '---') {
-        contentStart = i + 1; // line after closing ---
-        break;
-      }
-    }
-  }
-
-  // Find slide break positions (--- on its own line, after frontmatter)
-  const slideStarts: number[] = [contentStart];
-  for (let i = contentStart; i < totalLines; i++) {
-    if (lines[i]?.trim() === '---') {
-      slideStarts.push(i + 1);
-    }
-  }
-
-  const ranges: { startLine: number; endLine: number }[] = [];
-  for (let i = 0; i < slideStarts.length; i++) {
-    const start = slideStarts[i];
-    const end = (i + 1 < slideStarts.length) ? slideStarts[i + 1] - 2 : totalLines - 1;
-    ranges.push({ startLine: start, endLine: Math.max(start, end) });
-  }
-  return ranges;
-}
+const FULLSCREEN_Z_INDEX = 9999;
+const FULLSCREEN_BUTTON_OFFSET_PX = 16;
+const SLIDE_COUNTER_MIN_WIDTH_PX = 60;
 
 const MarpPreview: React.FC<MarpPreviewProps> = ({
   content,
@@ -200,9 +67,9 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
       // Inline relative images as data URLs so the iframe can display them
       if (filePath) {
         try {
-          html = await inlineRelativeImages(html, filePath);
+          html = await inlineMarpRelativeImages(html, filePath);
         } catch (err) {
-          console.error('[MarpPreview] inlineRelativeImages failed:', err);
+          console.error('[MarpPreview] inlineMarpRelativeImages failed:', err);
         }
         if (stale) return;
       }
@@ -221,25 +88,9 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
   // Compute slide line ranges from source content (memoized)
   const slideRanges = React.useMemo(() => computeSlideLineRanges(content), [content]);
 
-  /**
-   * Convert editor scrollFraction to { slideIndex, subFraction }.
-   * scrollFraction maps linearly to source lines; we find which slide
-   * that line falls in and how far through that slide we are.
-   */
   const fractionToSlide = useCallback((fraction: number) => {
     const totalLines = content.split('\n').length;
-    const currentLine = fraction * (totalLines - 1);
-
-    // Find which slide contains this line
-    for (let i = slideRanges.length - 1; i >= 0; i--) {
-      if (currentLine >= slideRanges[i].startLine) {
-        const range = slideRanges[i];
-        const rangeSize = range.endLine - range.startLine;
-        const sub = rangeSize > 0 ? (currentLine - range.startLine) / rangeSize : 0;
-        return { slideIndex: i, subFraction: Math.min(1, Math.max(0, sub)) };
-      }
-    }
-    return { slideIndex: 0, subFraction: 0 };
+    return scrollFractionToSlidePosition(fraction, totalLines, slideRanges);
   }, [content, slideRanges]);
 
   // Scroll sync for continuous mode — directly manipulate iframe DOM
@@ -391,7 +242,7 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
           left: 0,
           width: '100vw',
           height: '100vh',
-          zIndex: 9999,
+          zIndex: FULLSCREEN_Z_INDEX,
           backgroundColor: '#000',
           display: 'flex',
           alignItems: 'center',
@@ -432,8 +283,8 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
             onClick={toggleFullscreen}
             sx={{
               position: 'absolute',
-              top: 16,
-              right: 16,
+              top: FULLSCREEN_BUTTON_OFFSET_PX,
+              right: FULLSCREEN_BUTTON_OFFSET_PX,
               color: 'rgba(255,255,255,0.5)',
               '&:hover': { color: 'rgba(255,255,255,0.9)', backgroundColor: 'rgba(255,255,255,0.1)' },
             }}
@@ -447,7 +298,7 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
           variant="body2"
           sx={{
             position: 'absolute',
-            bottom: 16,
+            bottom: FULLSCREEN_BUTTON_OFFSET_PX,
             left: '50%',
             transform: 'translateX(-50%)',
             color: 'rgba(255,255,255,0.5)',
@@ -507,7 +358,7 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
               </IconButton>
             </span>
           </Tooltip>
-          <Typography variant="body2" color="text.secondary" sx={{ minWidth: 60, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary" sx={{ minWidth: SLIDE_COUNTER_MIN_WIDTH_PX, textAlign: 'center' }}>
             {slideCount > 0 ? `${currentSlide + 1} / ${slideCount}` : '—'}
           </Typography>
           <Tooltip title={t('preview.nextSlide', 'Next Slide')}>

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -12,6 +12,7 @@ import { RenderingSettings, DEFAULT_RENDERING_SETTINGS } from '../types/settings
 import { renderCode, processKatex, contentHasKatex, processMermaidBlocks, contentHasMermaid, reinitializeMermaid } from '../utils/markdownRenderers';
 import { buildExportHTML } from '../utils/exportStyles';
 import { contentIsMarp } from '../utils/marpRenderer';
+import { dirnameOf, isAbsoluteUrl, mimeTypeFromPath, resolveRelativePath } from '../utils/imagePathResolver';
 import MarpPreview from './MarpPreview';
 
 interface PreviewProps {
@@ -28,21 +29,8 @@ interface PreviewProps {
   viewMode?: 'split' | 'editor' | 'preview';
 }
 
-/** Resolve a relative path against a base directory path */
-function resolveRelativePath(baseDirPath: string, relativePath: string): string {
-  // Normalize separators to /
-  const parts = (baseDirPath + '/' + relativePath).split('/').filter(Boolean);
-  const resolved: string[] = [];
-  for (const part of parts) {
-    if (part === '.') continue;
-    if (part === '..') {
-      resolved.pop();
-    } else {
-      resolved.push(part);
-    }
-  }
-  return '/' + resolved.join('/');
-}
+const BASE_PREVIEW_FONT_SIZE_PX = 16;
+const BASE_PREVIEW_LINE_HEIGHT = 1.6;
 
 const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, globalVariables = {}, zoomLevel = 1.0, onContentChange, scrollFraction, onScrollChange, filePath, renderingSettings = DEFAULT_RENDERING_SETTINGS, viewMode = 'split' }) => {
   const isMarp = renderingSettings.enableMarp && contentIsMarp(content);
@@ -166,7 +154,7 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
 
         // Resolve relative image paths to blob URLs
         if (filePath) {
-          const baseDir = filePath.substring(0, filePath.lastIndexOf('/'));
+          const baseDir = dirnameOf(filePath);
           const imgRegex = /<img\s+[^>]*?src="([^"]+)"[^>]*?>/g;
           let imgMatch;
           const replacements = new Map<string, string>();
@@ -174,18 +162,11 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
           const imgPromises: Promise<void>[] = [];
           while ((imgMatch = imgRegex.exec(processedHtml)) !== null) {
             const src = imgMatch[1];
-            if (!src.startsWith('http://') && !src.startsWith('https://') && !src.startsWith('data:') && !src.startsWith('blob:')) {
+            if (!isAbsoluteUrl(src)) {
               const absolutePath = resolveRelativePath(baseDir, src);
               imgPromises.push(
                 readFile(absolutePath).then(data => {
-                  const ext = src.split('.').pop()?.toLowerCase() || '';
-                  const mimeMap: Record<string, string> = {
-                    png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
-                    gif: 'image/gif', svg: 'image/svg+xml', webp: 'image/webp',
-                    bmp: 'image/bmp', ico: 'image/x-icon', avif: 'image/avif',
-                  };
-                  const mime = mimeMap[ext] || 'application/octet-stream';
-                  const blob = new Blob([data], { type: mime });
+                  const blob = new Blob([data], { type: mimeTypeFromPath(src) });
                   const blobUrl = URL.createObjectURL(blob);
                   replacements.set(src, blobUrl);
                 }).catch(err => {
@@ -408,8 +389,8 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
           className={`markdown-preview ${theme === 'darcula' ? 'hljs-dark' : (darkMode ? 'hljs-dark' : 'hljs-light')}`}
           dangerouslySetInnerHTML={{ __html: htmlContent }}
           style={{
-            fontSize: `${Math.round(16 * zoomLevel)}px`,
-            lineHeight: `${Math.round(1.6 * zoomLevel)}`,
+            fontSize: `${Math.round(BASE_PREVIEW_FONT_SIZE_PX * zoomLevel)}px`,
+            lineHeight: `${Math.round(BASE_PREVIEW_LINE_HEIGHT * zoomLevel)}`,
             fontFamily: theme === 'as400'
               ? '"IBM Plex Mono", "Courier New", Courier, monospace'
               : '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -48,6 +48,7 @@ import { AppSettings } from '../types/settings';
 import { storeApi } from '../api/storeApi';
 import { desktopApi } from '../api/desktopApi';
 import { variableApi } from '../api/variableApi';
+import { LANGUAGE_OPTIONS } from '../constants/languages';
 
 interface SettingsProps {
   open: boolean;
@@ -549,20 +550,11 @@ const Settings: React.FC<SettingsProps> = ({
                         onChange={(e) => handleSettingChange('interface', 'language', e.target.value)}
                         label={t('settings.language.selectLanguage')}
                       >
-                        <MenuItem value="en">{t('settings.language.english')}</MenuItem>
-                        <MenuItem value="ja">{t('settings.language.japanese')}</MenuItem>
-                        <MenuItem value="zh-CN">{t('settings.language.chinese')}</MenuItem>
-                        <MenuItem value="zh-Hant">{t('settings.language.chineseTraditional')}</MenuItem>
-                        <MenuItem value="es">{t('settings.language.spanish')}</MenuItem>
-                        <MenuItem value="hi">{t('settings.language.hindi')}</MenuItem>
-                        <MenuItem value="ru">{t('settings.language.russian')}</MenuItem>
-                        <MenuItem value="ko">{t('settings.language.korean')}</MenuItem>
-                        <MenuItem value="pt-BR">{t('settings.language.portuguese')}</MenuItem>
-                        <MenuItem value="ar">{t('settings.language.arabic')}</MenuItem>
-                        <MenuItem value="fr">{t('settings.language.french')}</MenuItem>
-                        <MenuItem value="de">{t('settings.language.german')}</MenuItem>
-                        <MenuItem value="id">{t('settings.language.indonesian')}</MenuItem>
-                        <MenuItem value="vi">{t('settings.language.vietnamese')}</MenuItem>
+                        {LANGUAGE_OPTIONS.map((option) => (
+                          <MenuItem key={option.value} value={option.value}>
+                            {t(option.translationKey)}
+                          </MenuItem>
+                        ))}
                       </Select>
                     </FormControl>
                   </CardContent>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -38,6 +38,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { dragConfig } from '../config/dragConfig';
+import { SIDEBAR_WIDTH_PX } from '../constants/layout';
 
 interface TabBarProps {
   tabs: TabType[];
@@ -418,7 +419,7 @@ const TabBar: React.FC<TabBarProps> = ({
       <Box
         sx={{
           ...(!embedded && {
-            width: 280,
+            width: SIDEBAR_WIDTH_PX,
             borderRight: 1,
             borderColor: 'divider',
           }),

--- a/src/constants/languages.ts
+++ b/src/constants/languages.ts
@@ -1,0 +1,26 @@
+/**
+ * Supported UI language options for the Settings dialog.
+ * `value` matches the i18next language code; `translationKey` is the
+ * i18n key under `settings.language.*` for the display name.
+ */
+export interface LanguageOption {
+  value: string;
+  translationKey: string;
+}
+
+export const LANGUAGE_OPTIONS: LanguageOption[] = [
+  { value: 'en', translationKey: 'settings.language.english' },
+  { value: 'ja', translationKey: 'settings.language.japanese' },
+  { value: 'zh-CN', translationKey: 'settings.language.chinese' },
+  { value: 'zh-Hant', translationKey: 'settings.language.chineseTraditional' },
+  { value: 'es', translationKey: 'settings.language.spanish' },
+  { value: 'hi', translationKey: 'settings.language.hindi' },
+  { value: 'ru', translationKey: 'settings.language.russian' },
+  { value: 'ko', translationKey: 'settings.language.korean' },
+  { value: 'pt-BR', translationKey: 'settings.language.portuguese' },
+  { value: 'ar', translationKey: 'settings.language.arabic' },
+  { value: 'fr', translationKey: 'settings.language.french' },
+  { value: 'de', translationKey: 'settings.language.german' },
+  { value: 'id', translationKey: 'settings.language.indonesian' },
+  { value: 'vi', translationKey: 'settings.language.vietnamese' },
+];

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,0 +1,13 @@
+/** Shared layout constants for panels and sidebars. */
+
+/** Width of the left sidebar (vertical tabs / folder tree / merged). */
+export const SIDEBAR_WIDTH_PX = 280;
+
+/** Divider thickness between the resizable sidebar sections. */
+export const SIDEBAR_DIVIDER_HEIGHT_PX = 4;
+
+/** Width of the outline and folder-tree drawer overlays. */
+export const DRAWER_WIDTH_PX = 280;
+
+/** Delay used to wait for a layout settle before focusing Monaco or dispatching resize. */
+export const LAYOUT_SETTLE_DELAY_MS = 50;

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -18,6 +18,13 @@ import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { useEasterEggs } from './useEasterEggs';
 import { useWhatsNew } from './useWhatsNew';
 
+/** How long the transient "Saved" status message stays visible in the status bar. */
+const SAVE_STATUS_DISPLAY_MS = 3000;
+
+/** Delay before requesting editor focus after switching into a mode that shows the editor.
+ * Gives Monaco time to finish mounting/layout before receiving focus. */
+const EDITOR_FOCUS_DELAY_MS = 100;
+
 export const useAppState = () => {
   const { t } = useTranslation();
 
@@ -34,7 +41,6 @@ export const useAppState = () => {
   const [saveStatusMessage, setSaveStatusMessage] = useState<string | null>(null);
   const saveStatusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const SAVE_STATUS_DISPLAY_MS = 3000;
   const showSaveStatus = useCallback((message: string) => {
     if (saveStatusTimerRef.current) {
       clearTimeout(saveStatusTimerRef.current);
@@ -390,7 +396,6 @@ export const useAppState = () => {
   }, []);
 
   // Focus editor when switching to a mode that shows the editor
-  const EDITOR_FOCUS_DELAY_MS = 100;
   useEffect(() => {
     if (isSettingsLoaded && (viewMode === 'split' || viewMode === 'editor')) {
       const timer = setTimeout(() => {

--- a/src/hooks/useResizableSidebar.ts
+++ b/src/hooks/useResizableSidebar.ts
@@ -1,0 +1,100 @@
+import React, { useCallback, useRef, useState } from 'react';
+
+/**
+ * Layout constraints for the merged "open editors + explorer" sidebar.
+ * Exported for tests and for consumers that need to respect the same bounds.
+ */
+export const RESIZABLE_SIDEBAR = {
+  initialTopSectionHeightPx: 200,
+  minTopSectionHeightPx: 80,
+  /** Reserved height at the bottom for explorer header + divider (~40 + 4 + slack). */
+  reservedBottomHeightPx: 48,
+  /** Reserved height when expanding the top section after a collapse. */
+  expandReservedBottomHeightPx: 120,
+};
+
+interface UseResizableSidebarResult {
+  sidebarRef: React.RefObject<HTMLDivElement | null>;
+  topSectionHeight: number;
+  bottomCollapsed: boolean;
+  isDragging: boolean;
+  toggleBottomCollapsed: () => void;
+  handleDividerMouseDown: (event: React.MouseEvent) => void;
+}
+
+/**
+ * Encapsulates the resizable divider between two sidebar sections
+ * (e.g. vertical tab list and folder tree panel).
+ *
+ * The bottom section can be collapsed by clicking its header; the top
+ * section's previous height is remembered and restored on expand.
+ */
+export function useResizableSidebar(): UseResizableSidebarResult {
+  const [topSectionHeight, setTopSectionHeight] = useState(RESIZABLE_SIDEBAR.initialTopSectionHeightPx);
+  const [bottomCollapsed, setBottomCollapsed] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const heightBeforeCollapseRef = useRef(0);
+  const isDraggingRef = useRef(false);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  const toggleBottomCollapsed = useCallback(() => {
+    if (bottomCollapsed) {
+      // Restore the previous height (or the initial default) clamped to available space.
+      const restoreHeight = heightBeforeCollapseRef.current || RESIZABLE_SIDEBAR.initialTopSectionHeightPx;
+      if (sidebarRef.current) {
+        const maxHeight = sidebarRef.current.getBoundingClientRect().height - RESIZABLE_SIDEBAR.expandReservedBottomHeightPx;
+        setTopSectionHeight(Math.min(restoreHeight, maxHeight));
+      } else {
+        setTopSectionHeight(restoreHeight);
+      }
+      setBottomCollapsed(false);
+      return;
+    }
+    // Save current height, then collapse the bottom section (header stays visible).
+    heightBeforeCollapseRef.current = topSectionHeight;
+    if (sidebarRef.current) {
+      const totalHeight = sidebarRef.current.getBoundingClientRect().height;
+      setTopSectionHeight(totalHeight - RESIZABLE_SIDEBAR.reservedBottomHeightPx);
+    }
+    setBottomCollapsed(true);
+  }, [bottomCollapsed, topSectionHeight]);
+
+  const handleDividerMouseDown = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    isDraggingRef.current = true;
+    setIsDragging(true);
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isDraggingRef.current || !sidebarRef.current) return;
+      const sidebarRect = sidebarRef.current.getBoundingClientRect();
+      const newHeight = ev.clientY - sidebarRect.top;
+      const maxHeight = sidebarRect.height - RESIZABLE_SIDEBAR.reservedBottomHeightPx;
+      const clamped = Math.max(RESIZABLE_SIDEBAR.minTopSectionHeightPx, Math.min(maxHeight, newHeight));
+      setTopSectionHeight(clamped);
+      setBottomCollapsed(false);
+    };
+
+    const onMouseUp = () => {
+      isDraggingRef.current = false;
+      setIsDragging(false);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, []);
+
+  return {
+    sidebarRef,
+    topSectionHeight,
+    bottomCollapsed,
+    isDragging,
+    toggleBottomCollapsed,
+    handleDividerMouseDown,
+  };
+}

--- a/src/utils/__tests__/imagePathResolver.test.ts
+++ b/src/utils/__tests__/imagePathResolver.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  IMAGE_MIME_MAP,
+  isAbsoluteUrl,
+  mimeTypeFromPath,
+  resolveRelativePath,
+  dirnameOf,
+} from '../imagePathResolver';
+
+describe('isAbsoluteUrl', () => {
+  it('returns true for http, https, data, and blob URLs', () => {
+    expect(isAbsoluteUrl('http://example.com/a.png')).toBe(true);
+    expect(isAbsoluteUrl('https://example.com/a.png')).toBe(true);
+    expect(isAbsoluteUrl('data:image/png;base64,AAAA')).toBe(true);
+    expect(isAbsoluteUrl('blob:http://localhost/x')).toBe(true);
+  });
+
+  it('returns false for relative paths', () => {
+    expect(isAbsoluteUrl('./img.png')).toBe(false);
+    expect(isAbsoluteUrl('../images/x.png')).toBe(false);
+    expect(isAbsoluteUrl('img.png')).toBe(false);
+  });
+});
+
+describe('mimeTypeFromPath', () => {
+  it('maps known extensions to their MIME types', () => {
+    expect(mimeTypeFromPath('pic.png')).toBe('image/png');
+    expect(mimeTypeFromPath('pic.jpg')).toBe('image/jpeg');
+    expect(mimeTypeFromPath('pic.jpeg')).toBe('image/jpeg');
+    expect(mimeTypeFromPath('pic.SVG')).toBe('image/svg+xml');
+  });
+
+  it('falls back to application/octet-stream for unknown extensions', () => {
+    expect(mimeTypeFromPath('file.xyz')).toBe('application/octet-stream');
+    expect(mimeTypeFromPath('noext')).toBe('application/octet-stream');
+  });
+
+  it('exposes the full MIME map', () => {
+    expect(IMAGE_MIME_MAP.webp).toBe('image/webp');
+    expect(IMAGE_MIME_MAP.avif).toBe('image/avif');
+  });
+});
+
+describe('resolveRelativePath', () => {
+  it('resolves ./ as the base directory', () => {
+    expect(resolveRelativePath('/home/user/docs', './img.png')).toBe('/home/user/docs/img.png');
+  });
+
+  it('resolves ../ to parent directory', () => {
+    expect(resolveRelativePath('/home/user/docs', '../img.png')).toBe('/home/user/img.png');
+  });
+
+  it('resolves multiple parent traversals', () => {
+    expect(resolveRelativePath('/a/b/c', '../../img.png')).toBe('/a/img.png');
+  });
+
+  it('handles plain relative paths without prefix', () => {
+    expect(resolveRelativePath('/a/b', 'img.png')).toBe('/a/b/img.png');
+  });
+});
+
+describe('dirnameOf', () => {
+  it('returns the directory portion of a file path', () => {
+    expect(dirnameOf('/home/user/docs/file.md')).toBe('/home/user/docs');
+  });
+
+  it('returns empty string for a path without slashes', () => {
+    expect(dirnameOf('file.md')).toBe('');
+  });
+});

--- a/src/utils/__tests__/marpSlideRanges.test.ts
+++ b/src/utils/__tests__/marpSlideRanges.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeSlideLineRanges,
+  scrollFractionToSlidePosition,
+} from '../marpSlideRanges';
+
+describe('computeSlideLineRanges', () => {
+  it('returns a single slide when content has no separators', () => {
+    const content = 'line 1\nline 2\nline 3';
+    const ranges = computeSlideLineRanges(content);
+    expect(ranges).toEqual([{ startLine: 0, endLine: 2 }]);
+  });
+
+  it('treats frontmatter as part of the first slide', () => {
+    const content = [
+      '---',
+      'marp: true',
+      '---',
+      '# Slide 1',
+      '---',
+      '# Slide 2',
+    ].join('\n');
+
+    const ranges = computeSlideLineRanges(content);
+    expect(ranges.length).toBe(2);
+    expect(ranges[0].startLine).toBe(3); // line after closing ---
+    expect(ranges[1].startLine).toBe(5);
+  });
+
+  it('separates multiple slides', () => {
+    const content = [
+      '# A',
+      '---',
+      '# B',
+      '---',
+      '# C',
+    ].join('\n');
+    const ranges = computeSlideLineRanges(content);
+    expect(ranges.length).toBe(3);
+    expect(ranges[0].startLine).toBe(0);
+    expect(ranges[1].startLine).toBe(2);
+    expect(ranges[2].startLine).toBe(4);
+  });
+});
+
+describe('scrollFractionToSlidePosition', () => {
+  const ranges = [
+    { startLine: 0, endLine: 1 },
+    { startLine: 2, endLine: 3 },
+    { startLine: 4, endLine: 5 },
+  ];
+
+  it('maps fraction 0 to the first slide', () => {
+    expect(scrollFractionToSlidePosition(0, 6, ranges).slideIndex).toBe(0);
+  });
+
+  it('maps fraction 1 to the last slide', () => {
+    const pos = scrollFractionToSlidePosition(1, 6, ranges);
+    expect(pos.slideIndex).toBe(2);
+  });
+
+  it('clamps sub-fraction between 0 and 1', () => {
+    const pos = scrollFractionToSlidePosition(0.5, 6, ranges);
+    expect(pos.subFraction).toBeGreaterThanOrEqual(0);
+    expect(pos.subFraction).toBeLessThanOrEqual(1);
+  });
+
+  it('returns zero position for empty ranges', () => {
+    const pos = scrollFractionToSlidePosition(0.5, 6, []);
+    expect(pos).toEqual({ slideIndex: 0, subFraction: 0 });
+  });
+});

--- a/src/utils/imagePathResolver.ts
+++ b/src/utils/imagePathResolver.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared helpers for resolving relative image paths in rendered preview HTML.
+ * Used by both MarpPreview (iframe data URLs) and Preview (blob URLs).
+ */
+
+/** MIME types for supported image extensions. */
+export const IMAGE_MIME_MAP: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  avif: 'image/avif',
+};
+
+const DEFAULT_MIME = 'application/octet-stream';
+
+/** Check if a URL is absolute (http, https, data, blob). */
+export function isAbsoluteUrl(src: string): boolean {
+  return (
+    src.startsWith('http://') ||
+    src.startsWith('https://') ||
+    src.startsWith('data:') ||
+    src.startsWith('blob:')
+  );
+}
+
+/** Look up the MIME type for a file path's extension. */
+export function mimeTypeFromPath(src: string): string {
+  const ext = src.split('.').pop()?.toLowerCase() || '';
+  return IMAGE_MIME_MAP[ext] || DEFAULT_MIME;
+}
+
+/** Resolve a relative path against a base directory path, collapsing . and .. segments. */
+export function resolveRelativePath(baseDirPath: string, relativePath: string): string {
+  const parts = (baseDirPath + '/' + relativePath).split('/').filter(Boolean);
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === '.') continue;
+    if (part === '..') {
+      resolved.pop();
+    } else {
+      resolved.push(part);
+    }
+  }
+  return '/' + resolved.join('/');
+}
+
+/** Extract the directory portion of a file path (no trailing slash). */
+export function dirnameOf(filePath: string): string {
+  return filePath.substring(0, filePath.lastIndexOf('/'));
+}

--- a/src/utils/marpImageInliner.ts
+++ b/src/utils/marpImageInliner.ts
@@ -1,0 +1,69 @@
+import { readFile } from '@tauri-apps/plugin-fs';
+import { dirnameOf, isAbsoluteUrl, mimeTypeFromPath, resolveRelativePath } from './imagePathResolver';
+
+/**
+ * Replace relative image references in Marp HTML with inline data URLs.
+ * Data URLs are used (instead of blob URLs) so the sandboxed iframe can
+ * display images without a same-origin relationship to the host document.
+ *
+ * Handles:
+ * - <img src="..."> tags
+ * - CSS url("...") patterns (Marp background images)
+ * - <image href="..."> / <image xlink:href="..."> SVG elements
+ */
+export async function inlineMarpRelativeImages(html: string, filePath: string): Promise<string> {
+  const baseDir = dirnameOf(filePath);
+  const replacements = new Map<string, string>();
+  const promises: Promise<void>[] = [];
+
+  function collectSrc(src: string) {
+    if (isAbsoluteUrl(src) || replacements.has(src)) return;
+    replacements.set(src, src); // reserve to avoid duplicate work
+    const absolutePath = resolveRelativePath(baseDir, src);
+    promises.push(
+      readAsDataUrl(absolutePath, src)
+        .then((dataUrl) => {
+          replacements.set(src, dataUrl);
+        })
+        .catch((err) => {
+          console.error('[MarpPreview] Failed to inline image:', absolutePath, err);
+        }),
+    );
+  }
+
+  collectMatches(html, /<img\s+[^>]*?src="([^"]+)"[^>]*?>/g, collectSrc);
+  // Marp encodes quotes as HTML entities in inline styles
+  collectMatches(html, /url\(&quot;([^&]+)&quot;\)/g, collectSrc);
+  // Fallback for unencoded quotes
+  collectMatches(html, /url\("([^"]+)"\)/g, collectSrc);
+  collectMatches(html, /<image\s+[^>]*?(?:xlink:)?href="([^"]+)"[^>]*?>/g, collectSrc);
+
+  await Promise.all(promises);
+
+  let result = html;
+  for (const [original, dataUrl] of replacements) {
+    if (dataUrl === original) continue;
+    result = result.split(`src="${original}"`).join(`src="${dataUrl}"`);
+    result = result.split(`url(&quot;${original}&quot;)`).join(`url(&quot;${dataUrl}&quot;)`);
+    result = result.split(`url("${original}")`).join(`url("${dataUrl}")`);
+    result = result.split(`href="${original}"`).join(`href="${dataUrl}"`);
+  }
+  return result;
+}
+
+function collectMatches(html: string, regex: RegExp, onMatch: (src: string) => void) {
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(html)) !== null) {
+    onMatch(match[1]);
+  }
+}
+
+async function readAsDataUrl(absolutePath: string, src: string): Promise<string> {
+  const data = await readFile(absolutePath);
+  const mime = mimeTypeFromPath(src);
+  let binary = '';
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i]);
+  }
+  return `data:${mime};base64,${btoa(binary)}`;
+}

--- a/src/utils/marpSlideRanges.ts
+++ b/src/utils/marpSlideRanges.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers for mapping editor line positions to Marp slide boundaries.
+ * Extracted from MarpPreview to keep the rendering component lean and
+ * make the pure computation unit-testable.
+ */
+
+export interface SlideLineRange {
+  startLine: number;
+  endLine: number;
+}
+
+export interface SlidePosition {
+  slideIndex: number;
+  subFraction: number;
+}
+
+const FRONTMATTER_DELIMITER = '---';
+
+/**
+ * Compute the line ranges for each Marp slide from the source content.
+ * Returns an array of { startLine, endLine } (0-based, inclusive).
+ * The frontmatter block (first --- ... ---) is treated as part of slide 0.
+ */
+export function computeSlideLineRanges(content: string): SlideLineRange[] {
+  const lines = content.split('\n');
+  const totalLines = lines.length;
+
+  // Find frontmatter end (second ---)
+  let contentStart = 0;
+  if (lines[0]?.trim() === FRONTMATTER_DELIMITER) {
+    for (let i = 1; i < totalLines; i++) {
+      if (lines[i]?.trim() === FRONTMATTER_DELIMITER) {
+        contentStart = i + 1;
+        break;
+      }
+    }
+  }
+
+  // Find slide break positions (--- on its own line, after frontmatter)
+  const slideStarts: number[] = [contentStart];
+  for (let i = contentStart; i < totalLines; i++) {
+    if (lines[i]?.trim() === FRONTMATTER_DELIMITER) {
+      slideStarts.push(i + 1);
+    }
+  }
+
+  const ranges: SlideLineRange[] = [];
+  for (let i = 0; i < slideStarts.length; i++) {
+    const start = slideStarts[i];
+    const end = i + 1 < slideStarts.length ? slideStarts[i + 1] - 2 : totalLines - 1;
+    ranges.push({ startLine: start, endLine: Math.max(start, end) });
+  }
+  return ranges;
+}
+
+/**
+ * Convert an editor scroll fraction (0..1) into a slide index and a
+ * sub-fraction indicating how far through that slide the scroll is.
+ * scrollFraction maps linearly to source lines; we find which slide
+ * that line falls in and how far through that slide we are.
+ */
+export function scrollFractionToSlidePosition(
+  fraction: number,
+  totalLines: number,
+  ranges: SlideLineRange[],
+): SlidePosition {
+  const currentLine = fraction * (totalLines - 1);
+
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    if (currentLine >= ranges[i].startLine) {
+      const range = ranges[i];
+      const rangeSize = range.endLine - range.startLine;
+      const sub = rangeSize > 0 ? (currentLine - range.startLine) / rangeSize : 0;
+      return { slideIndex: i, subFraction: Math.min(1, Math.max(0, sub)) };
+    }
+  }
+  return { slideIndex: 0, subFraction: 0 };
+}


### PR DESCRIPTION
## Summary

New modules (extracted for DRY + testability):
- src/utils/imagePathResolver.ts — shared resolveRelativePath, isAbsoluteUrl, mimeTypeFromPath, dirnameOf, IMAGE_MIME_MAP (was duplicated in Preview.tsx and MarpPreview.tsx)
- src/utils/marpImageInliner.ts — inlineMarpRelativeImages extracted from MarpPreview.tsx
- src/utils/marpSlideRanges.ts — pure computeSlideLineRanges + scrollFractionToSlidePosition extracted from MarpPreview.tsx
- src/hooks/useResizableSidebar.ts — sidebar resize state/handlers extracted from AppContent.tsx
- src/constants/layout.ts — SIDEBAR_WIDTH_PX, DRAWER_WIDTH_PX, SIDEBAR_DIVIDER_HEIGHT_PX, LAYOUT_SETTLE_DELAY_MS
- src/constants/languages.ts — LANGUAGE_OPTIONS (was 14 inline <MenuItem> in Settings.tsx)

### New tests
imagePathResolver.test.ts (12 tests), marpSlideRanges.test.ts (6 tests) — +18 total.

### Magic numbers named in-place
FULLSCREEN_Z_INDEX, FULLSCREEN_BUTTON_OFFSET_PX, SLIDE_COUNTER_MIN_WIDTH_PX (MarpPreview); BASE_PREVIEW_FONT_SIZE_PX, BASE_PREVIEW_LINE_HEIGHT
(Preview); SAVE_STATUS_DISPLAY_MS, EDITOR_FOCUS_DELAY_MS hoisted to module scope (useAppState).

### Net effect
MarpPreview.tsx 581→410 lines, AppContent.tsx 610→540 lines; duplication removed; previously-inline logic now unit-tested.