### PR TITLE
Always open preview links in the OS browser

### DIFF
--- a/src/components/MarpPreview.tsx
+++ b/src/components/MarpPreview.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Box, Typography, IconButton, Tooltip } from '@mui/material';
 import { NavigateBefore, NavigateNext, Fullscreen, FullscreenExit, GridView } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { variableApi } from '../api/variableApi';
 import { renderMarp, buildSlideDocument, buildAllSlidesDocument, buildThumbnailDocument } from '../utils/marpRenderer';
 import { inlineMarpRelativeImages } from '../utils/marpImageInliner';
@@ -181,13 +182,28 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
     }
   }, [isSlideMode]);
 
-  // Listen for postMessage from thumbnail iframe (slide selection)
+  // Listen for postMessage from iframes:
+  //   - slideSelect: thumbnail click (changes current slide)
+  //   - openExternalUrl: link click inside any slide iframe — must be routed
+  //     through the OS browser via the Tauri opener plugin. Direct iframe
+  //     navigation would render the linked page inside the slide region.
   const thumbnailIframeRef = useRef<HTMLIFrameElement>(null);
   useEffect(() => {
     const handleMessage = (e: MessageEvent) => {
       if (e.data?.type === 'slideSelect' && typeof e.data.slideIndex === 'number') {
         setCurrentSlide(e.data.slideIndex);
         setIsThumbnailMode(false);
+        return;
+      }
+      if (e.data?.type === 'openExternalUrl' && typeof e.data.url === 'string') {
+        // Re-validate the scheme on the host side — never trust the iframe alone.
+        const url = e.data.url;
+        if (/^(https?:|mailto:)/i.test(url)) {
+          openUrl(url).catch((err) => {
+            console.error('[MarpPreview] Failed to open URL:', url, err);
+          });
+        }
+        return;
       }
     };
     window.addEventListener('message', handleMessage);

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -207,6 +207,12 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
   // Using delegation avoids the gap between DOM replacement and listener attachment,
   // and capturing ensures we intercept clicks on child elements (e.g. <img> inside <a>)
   // before the default navigation can occur.
+  //
+  // Depend on `isMarp` because the `<div ref={previewRef}>` is conditionally
+  // rendered (the Marp branch returns <MarpPreview/> early). If a Marp tab is
+  // active on first mount, previewRef.current is null when the effect runs;
+  // toggling to a non-Marp tab later mounts the div, and we need the effect
+  // to re-run so the listener actually attaches.
   useEffect(() => {
     const container = previewRef.current;
     if (!container) return;
@@ -236,11 +242,12 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
 
     container.addEventListener('click', handler, true);
     return () => container.removeEventListener('click', handler, true);
-  }, []);
+  }, [isMarp]);
 
   // Handle checkbox toggle via event delegation on the container.
   // The container element itself persists across dangerouslySetInnerHTML updates,
   // so a single listener reliably catches events from dynamically replaced children.
+  // See the link-click effect above for why we depend on `isMarp`.
   useEffect(() => {
     const container = previewRef.current;
     if (!container) return;
@@ -280,7 +287,7 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
 
     container.addEventListener('change', handleCheckboxChange);
     return () => container.removeEventListener('change', handleCheckboxChange);
-  }, []);
+  }, [isMarp]);
 
 
 

--- a/src/components/__tests__/MarpPreview.test.tsx
+++ b/src/components/__tests__/MarpPreview.test.tsx
@@ -1,8 +1,9 @@
-import { render, waitFor, fireEvent } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { render, waitFor, fireEvent, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 // Mock Tauri plugins
 vi.mock('@tauri-apps/api/core');
+vi.mock('@tauri-apps/plugin-opener');
 
 vi.mock('../../api/variableApi', () => ({
   variableApi: {
@@ -23,6 +24,7 @@ vi.mock('../../utils/marpRenderer', () => ({
     (_html: string, _css: string, index: number) => `<html><body>Slide ${index + 1}</body></html>`,
   ),
   buildAllSlidesDocument: vi.fn().mockReturnValue('<html><body>All Slides</body></html>'),
+  buildThumbnailDocument: vi.fn().mockReturnValue('<html><body>Thumbnails</body></html>'),
 }));
 
 // Mock react-i18next
@@ -33,6 +35,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 import MarpPreview from '../MarpPreview';
+import { openUrl } from '@tauri-apps/plugin-opener';
 
 const defaultProps = {
   content: '---\nmarp: true\n---\n# Slide 1\n---\n# Slide 2\n---\n# Slide 3',
@@ -141,5 +144,69 @@ describe('MarpPreview - continuous mode (split)', () => {
     // In continuous mode, there should be no navigation buttons
     const buttons = queryAllByRole('button');
     expect(buttons.length).toBe(0);
+  });
+});
+
+// T-MP-LINK: openExternalUrl postMessage from any iframe must be routed to
+// the OS browser via openUrl, never followed inside the webview. Unsafe
+// schemes (javascript:, file:, data:, etc.) must be silently dropped.
+describe('MarpPreview - openExternalUrl postMessage handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (openUrl as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it('forwards http(s) URLs to openUrl', async () => {
+    const { getByText } = render(<MarpPreview {...defaultProps} viewMode="preview" />);
+    await waitFor(() => expect(getByText('1 / 3')).toBeTruthy());
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { type: 'openExternalUrl', url: 'https://example.com/page' } }),
+      );
+    });
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/page');
+  });
+
+  it('forwards mailto URLs to openUrl', async () => {
+    const { getByText } = render(<MarpPreview {...defaultProps} viewMode="preview" />);
+    await waitFor(() => expect(getByText('1 / 3')).toBeTruthy());
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { type: 'openExternalUrl', url: 'mailto:foo@example.com' } }),
+      );
+    });
+
+    expect(openUrl).toHaveBeenCalledWith('mailto:foo@example.com');
+  });
+
+  it('drops javascript: and file: URLs without calling openUrl', async () => {
+    const { getByText } = render(<MarpPreview {...defaultProps} viewMode="preview" />);
+    await waitFor(() => expect(getByText('1 / 3')).toBeTruthy());
+
+    for (const url of ['javascript:alert(1)', 'file:///etc/passwd', 'data:text/html,<script>x</script>']) {
+      act(() => {
+        window.dispatchEvent(
+          new MessageEvent('message', { data: { type: 'openExternalUrl', url } }),
+        );
+      });
+    }
+
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+
+  it('ignores openExternalUrl messages with non-string url payloads', async () => {
+    const { getByText } = render(<MarpPreview {...defaultProps} viewMode="preview" />);
+    await waitFor(() => expect(getByText('1 / 3')).toBeTruthy());
+
+    for (const payload of [{ type: 'openExternalUrl' }, { type: 'openExternalUrl', url: 42 }, { type: 'openExternalUrl', url: null }]) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', { data: payload }));
+      });
+    }
+
+    expect(openUrl).not.toHaveBeenCalled();
   });
 });

--- a/src/components/__tests__/Preview.test.tsx
+++ b/src/components/__tests__/Preview.test.tsx
@@ -100,6 +100,7 @@ import { variableApi } from '../../api/variableApi';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { processKatex, contentHasKatex, processMermaidBlocks, contentHasMermaid } from '../../utils/markdownRenderers';
 import { contentIsMarp } from '../../utils/marpRenderer';
+import { DEFAULT_RENDERING_SETTINGS } from '../../types/settings';
 
 /**
  * Helper: render the Preview component and wait until the async markdown
@@ -578,5 +579,87 @@ describe('MarkdownPreview – link clicks', () => {
 
     expect(preventDefaultSpy).toHaveBeenCalled();
     expect(openUrl).toHaveBeenCalledWith('https://google.com');
+  });
+
+  // T-PV-17 / T-PV-18 (regression): both the link-click and checkbox-change
+  // listeners must attach even after the component first mounts as a Marp
+  // preview (which returns <MarpPreview/> early and leaves previewRef null)
+  // and then switches to a non-Marp tab. Before the fix, both listeners'
+  // useEffect had empty deps, so they ran once while previewRef was null and
+  // never re-attached when the markdown div finally mounted — link clicks
+  // fell through to native navigation (the app navigated inside Bokuchi
+  // instead of opening the OS browser) and checkbox clicks did nothing.
+  //
+  // These tests are paired: if the early-return-for-Marp pattern at
+  // Preview.tsx:358 is preserved AND either useEffect's deps drift back to
+  // `[]`, one of these tests will fail.
+  it('T-PV-17: link listener attaches after switching from Marp to non-Marp content', async () => {
+    // Start as Marp: contentIsMarp -> true, so MarpPreview branch is taken
+    // and the markdown <div ref={previewRef}> never mounts on first render.
+    vi.mocked(contentIsMarp).mockReturnValue(true);
+    const { rerender, container } = render(
+      <MarkdownPreview
+        content={'---\nmarp: true\n---\n# slide'}
+        darkMode={false}
+        renderingSettings={{ ...DEFAULT_RENDERING_SETTINGS, enableMarp: true }}
+      />,
+    );
+    // Sanity: Marp branch active, markdown div absent.
+    expect(container.querySelector('[data-testid="marp-preview"]')).not.toBeNull();
+    expect(container.querySelector('.markdown-preview')).toBeNull();
+
+    // Switch to a regular markdown document — the markdown div now mounts.
+    vi.mocked(contentIsMarp).mockReturnValue(false);
+    rerender(
+      <MarkdownPreview
+        content={'[Google](https://google.com)'}
+        darkMode={false}
+        renderingSettings={{ ...DEFAULT_RENDERING_SETTINGS, enableMarp: true }}
+      />,
+    );
+    await waitFor(() => {
+      const link = container.querySelector('a[href="https://google.com"]');
+      expect(link).not.toBeNull();
+    });
+
+    const link = container.querySelector('a[href="https://google.com"]') as HTMLAnchorElement;
+    fireEvent.click(link);
+
+    expect(openUrl).toHaveBeenCalledWith('https://google.com');
+  });
+
+  it('T-PV-18: checkbox listener attaches after switching from Marp to non-Marp content', async () => {
+    const onContentChange = vi.fn<(newContent: string) => void>();
+
+    vi.mocked(contentIsMarp).mockReturnValue(true);
+    const { rerender, container } = render(
+      <MarkdownPreview
+        content={'---\nmarp: true\n---\n# slide'}
+        darkMode={false}
+        onContentChange={onContentChange}
+        renderingSettings={{ ...DEFAULT_RENDERING_SETTINGS, enableMarp: true }}
+      />,
+    );
+    expect(container.querySelector('[data-testid="marp-preview"]')).not.toBeNull();
+    expect(container.querySelector('.markdown-preview')).toBeNull();
+
+    vi.mocked(contentIsMarp).mockReturnValue(false);
+    rerender(
+      <MarkdownPreview
+        content={'- [ ] Buy milk'}
+        darkMode={false}
+        onContentChange={onContentChange}
+        renderingSettings={{ ...DEFAULT_RENDERING_SETTINGS, enableMarp: true }}
+      />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('input.markdown-checkbox')).not.toBeNull();
+    });
+
+    const checkbox = container.querySelector('input.markdown-checkbox') as HTMLInputElement;
+    checkbox.checked = true;
+    fireEvent.change(checkbox);
+
+    expect(onContentChange).toHaveBeenCalledWith('- [x] Buy milk');
   });
 });

--- a/src/utils/__tests__/marpRenderer.test.ts
+++ b/src/utils/__tests__/marpRenderer.test.ts
@@ -12,7 +12,15 @@ vi.mock('@marp-team/marp-core', () => ({
   },
 }));
 
-import { contentIsMarp, renderMarp, countSlides, buildSlideDocument, buildAllSlidesDocument } from '../marpRenderer';
+import {
+  contentIsMarp,
+  renderMarp,
+  countSlides,
+  buildSlideDocument,
+  buildAllSlidesDocument,
+  buildThumbnailDocument,
+  LINK_INTERCEPTOR_SCRIPT,
+} from '../marpRenderer';
 
 describe('contentIsMarp', () => {
   it('returns true for markdown with marp: true in frontmatter', () => {
@@ -148,5 +156,46 @@ describe('buildAllSlidesDocument', () => {
     const doc = buildAllSlidesDocument('html', 'css');
     expect(doc).not.toContain('nth-child');
     expect(doc).not.toContain('display: none');
+  });
+});
+
+// T-MR-LINK: Link interception script must be embedded in every iframe srcdoc
+// so that anchor clicks inside sandboxed Marp iframes are forwarded to the
+// host instead of navigating the iframe to the linked website. This is a
+// hard security requirement (see: open-link bug fix).
+describe('link interceptor injection', () => {
+  it('LINK_INTERCEPTOR_SCRIPT posts http(s)/mailto URLs to parent and drops other schemes', () => {
+    expect(LINK_INTERCEPTOR_SCRIPT).toContain("postMessage");
+    expect(LINK_INTERCEPTOR_SCRIPT).toContain("openExternalUrl");
+    expect(LINK_INTERCEPTOR_SCRIPT).toContain("(https?:|mailto:)");
+    expect(LINK_INTERCEPTOR_SCRIPT).toContain("preventDefault");
+    expect(LINK_INTERCEPTOR_SCRIPT).toContain("stopPropagation");
+    // Capture phase listener
+    expect(LINK_INTERCEPTOR_SCRIPT).toMatch(/addEventListener\([^)]*'click'[^)]*true\s*\)/);
+  });
+
+  it('buildSlideDocument injects link interceptor', () => {
+    const doc = buildSlideDocument('<div class="marpit">x</div>', 'css', 0);
+    expect(doc).toContain(LINK_INTERCEPTOR_SCRIPT);
+  });
+
+  it('buildAllSlidesDocument injects link interceptor', () => {
+    const doc = buildAllSlidesDocument('<div class="marpit">x</div>', 'css');
+    expect(doc).toContain(LINK_INTERCEPTOR_SCRIPT);
+  });
+
+  it('buildThumbnailDocument injects link interceptor', () => {
+    const doc = buildThumbnailDocument('<div class="marpit">x</div>', 'css', 0);
+    expect(doc).toContain(LINK_INTERCEPTOR_SCRIPT);
+  });
+
+  // <base target="_blank"> was tried as belt-and-braces but caused Marp SVG
+  // <use href="#defs"> to fail to resolve in some webview engines, blanking
+  // the slide. The JS interceptor's preventDefault() makes the base element
+  // unnecessary, so it must remain absent.
+  it('does not include <base target="_blank"> (regression: blanks SVG slides)', () => {
+    expect(buildSlideDocument('html', 'css', 0)).not.toContain('<base');
+    expect(buildAllSlidesDocument('html', 'css')).not.toContain('<base');
+    expect(buildThumbnailDocument('html', 'css', 0)).not.toContain('<base');
   });
 });

--- a/src/utils/marpRenderer.ts
+++ b/src/utils/marpRenderer.ts
@@ -48,6 +48,47 @@ export function countSlides(html: string): number {
 }
 
 /**
+ * JS snippet injected into every Marp iframe srcdoc.
+ * Intercepts all link clicks (capture phase) and forwards external URLs to
+ * the parent window via postMessage so the host can route them to the OS
+ * browser. Without this, sandboxed iframes navigate internally and replace
+ * the slide rendering with the linked website.
+ *
+ * Hosting code must listen for `{ type: 'openExternalUrl', url }` messages
+ * and validate the URL again before opening it.
+ */
+export const LINK_INTERCEPTOR_SCRIPT = `
+(function() {
+  function handleClick(e) {
+    var el = e.target;
+    while (el && el.nodeType === 1 && el.tagName !== 'A') {
+      el = el.parentNode;
+    }
+    if (!el || el.tagName !== 'A') return;
+    var href = el.getAttribute('href');
+    if (!href) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (/^(https?:|mailto:)/i.test(href)) {
+      try {
+        window.parent.postMessage({ type: 'openExternalUrl', url: href }, '*');
+      } catch (err) {}
+    } else if (href.charAt(0) === '#') {
+      try {
+        var target = document.querySelector(href);
+        if (target && target.scrollIntoView) {
+          target.scrollIntoView({ behavior: 'smooth' });
+        }
+      } catch (err) {}
+    }
+    /* Other schemes (javascript:, file:, data:, etc.) are dropped. */
+  }
+  document.addEventListener('click', handleClick, true);
+  document.addEventListener('auxclick', handleClick, true);
+})();
+`;
+
+/**
  * Build a self-contained HTML document for iframe srcdoc.
  * All slides are loaded once; the visible slide is controlled via postMessage.
  * This avoids full document reloads on slide change, preventing CSS flicker.
@@ -115,6 +156,7 @@ window.addEventListener('message', function(e) {
     showSlide(e.data.slideIndex);
   }
 });
+${LINK_INTERCEPTOR_SCRIPT}
 </script>
 </body>
 </html>`;
@@ -265,6 +307,7 @@ div.marpit {
     }
   });
 })();
+${LINK_INTERCEPTOR_SCRIPT}
 </script>
 </body>
 </html>`;
@@ -306,6 +349,10 @@ div.marpit {
 }
 </style>
 </head>
-<body>${html}</body>
+<body>${html}
+<script>
+${LINK_INTERCEPTOR_SCRIPT}
+</script>
+</body>
 </html>`;
 }


### PR DESCRIPTION
## Summary

Force every link click in both the regular Markdown preview and the Marp slide preview to be routed through the OS default browser via `tauri-plugin-opener`. Previously, clicks
inside Marp slide iframes navigated the iframe to the linked site (rendering the page inside the slide region), and a latent bug in `Preview.tsx` left the link-click listener
unattached when a Marp tab was the first one opened, causing regular Markdown links to navigate inside Bokuchi as well.

## Changes

- **Marp iframe link interception**: Added a shared `LINK_INTERCEPTOR_SCRIPT` to `src/utils/marpRenderer.ts` and injected it into every iframe srcdoc produced by
`buildSlideDocument`, `buildAllSlidesDocument`, and `buildThumbnailDocument`. The script captures `<a>` clicks in capture phase, calls `preventDefault`, and posts `{ type:
'openExternalUrl', url }` to the parent window for `http(s)`/`mailto:` URLs (other schemes such as `javascript:`, `file:`, `data:` are dropped silently).
- **Host-side message handling**: Extended the existing `message` listener in `src/components/MarpPreview.tsx` to handle `openExternalUrl` messages. The host re-validates the URL
scheme against the same `^(https?:|mailto:)$` whitelist before calling `openUrl`, so the iframe is never trusted alone.
- **Fix latent listener-attachment bug in `Preview.tsx`**: Changed the dependency array of both the link-click delegation effect (line 245) and the checkbox change handler effect
(line 290) from `[]` to `[isMarp]`. The `<div ref={previewRef}>` is conditionally rendered (the component returns `<MarpPreview />` early when `isMarp` is true). Mounting on a
Marp tab and then switching to a non-Marp tab previously left `previewRef.current` null and the listeners never attached, causing all subsequent regular-Markdown link clicks to
fall through to native navigation.

## Tests

- **`src/components/__tests__/Preview.test.tsx`**: Added `T-PV-17` (link-click) and `T-PV-18` (checkbox-change) regression tests. Both mount with `contentIsMarp` mocked to `true`
(so `MarpPreview` takes over and the markdown div is absent), then re-render with `contentIsMarp` returning `false`, then assert that clicking the rendered link calls `openUrl`
and that toggling the rendered checkbox calls `onContentChange`. Both tests were verified to fail when the relevant `useEffect` deps are reverted to `[]`.
- **`src/components/__tests__/MarpPreview.test.tsx`**: Added four `openExternalUrl` postMessage tests covering: `http(s)` forwarded to `openUrl`, `mailto:` forwarded to `openUrl`,
dangerous schemes (`javascript:`, `file:`, `data:`) silently dropped, and malformed payloads (missing/non-string `url`) ignored.
- **`src/utils/__tests__/marpRenderer.test.ts`**: Added tests asserting the structure of `LINK_INTERCEPTOR_SCRIPT` (capture-phase listener, `preventDefault`, `postMessage`, scheme
regex), confirming each of the three `build*Document` functions injects the snippet, and a regression test guaranteeing no `<base>` tag is reintroduced (an earlier attempt
blanked Marp SVGs in the webview).