### PR TITLE
Fixed an issue where the scroll bar did not appear in the Marp previe…

### DIFF
--- a/src/components/MarpPreview.tsx
+++ b/src/components/MarpPreview.tsx
@@ -346,6 +346,12 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
               srcDoc={srcdoc}
               sandbox="allow-scripts allow-same-origin"
               title="Marp Slides Overview"
+              onLoad={() => {
+                // Force WebKit to re-evaluate scrollbar visibility after the
+                // iframe document finishes layout. On initial app startup the
+                // scrollbar can otherwise stay hidden even when content overflows.
+                iframeRef.current?.contentWindow?.dispatchEvent(new Event('resize'));
+              }}
               style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
             />
           )}


### PR DESCRIPTION
## Summary

When the app launched with a Marp document as the active tab in split view, the Marp preview iframe failed to show its scrollbar even though the content overflowed. This patch
forces WebKit to re-evaluate scrollbar visibility after the iframe finishes loading, restoring both the scrollbar and direct mouse-wheel scrolling.

## Changes

- `MarpPreview.tsx`: Add an `onLoad` handler to the continuous-mode (split view) iframe that dispatches a `resize` event into the iframe's `contentWindow`, prompting WebKit to
recompute overflow/scrollbar state once the Marp document has been laid out.

## Tests

No test changes.