### PR TITLE
Fix Marp fullscreen resetting to the first slide

### DIFF
--- a/src/components/MarpPreview.tsx
+++ b/src/components/MarpPreview.tsx
@@ -288,6 +288,11 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
               srcDoc={srcdoc}
               sandbox="allow-scripts"
               title="Marp Slide Fullscreen"
+              onLoad={() => {
+                fullscreenIframeRef.current?.contentWindow?.postMessage(
+                  { slideIndex: currentSlide }, '*'
+                );
+              }}
               style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
             />
           </Box>
@@ -443,6 +448,11 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
             srcDoc={srcdoc}
             sandbox="allow-scripts"
             title="Marp Slide Preview"
+            onLoad={() => {
+              slideIframeRef.current?.contentWindow?.postMessage(
+                { slideIndex: currentSlide }, '*'
+              );
+            }}
             style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
           />
         )}


### PR DESCRIPTION
## Summary

When entering fullscreen from Marp slide mode, the iframe always displayed the first slide instead of the slide the user was on. This PR sends the current slide index to the
iframe via postMessage on load so the correct slide is shown immediately on fullscreen entry (and on returning to slide mode).

## Changes

- Added an `onLoad` handler to the fullscreen Marp iframe that posts the current `slideIndex` to its content window, so a freshly mounted fullscreen iframe lands on the user's
current slide instead of slide 1.
- Added the same `onLoad` handler to the slide-mode iframe so exiting fullscreen also restores the correct slide on the re-mounted preview iframe.

## Tests

No test changes.