### PR TITLE
Check for updates periodically while the app is running

### DIFF
--- a/src/api/storeApi.ts
+++ b/src/api/storeApi.ts
@@ -445,6 +445,30 @@ export const storeApi = {
     }
   },
 
+  // Save last update check timestamp (epoch ms)
+  async saveLastUpdateCheckAt(timestamp: number): Promise<void> {
+    try {
+      const storeInstance = await getStore();
+      await storeInstance.set('lastUpdateCheckAt', timestamp);
+      await storeInstance.save();
+    } catch (error) {
+      console.error('Failed to save last update check timestamp:', error);
+      throw error;
+    }
+  },
+
+  // Load last update check timestamp (epoch ms)
+  async loadLastUpdateCheckAt(): Promise<number | null> {
+    try {
+      const storeInstance = await getStore();
+      const timestamp = await storeInstance.get('lastUpdateCheckAt') as number | null;
+      return typeof timestamp === 'number' ? timestamp : null;
+    } catch (error) {
+      console.error('Failed to load last update check timestamp:', error);
+      return null;
+    }
+  },
+
   // Load folder tree root path
   async loadFolderTreeRoot(): Promise<string | null> {
     try {

--- a/src/hooks/__tests__/useUpdateChecker.test.ts
+++ b/src/hooks/__tests__/useUpdateChecker.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../api/updaterApi', () => ({
   updaterApi: {
@@ -11,12 +11,23 @@ vi.mock('../../api/updaterApi', () => ({
   },
 }));
 
+vi.mock('../../api/storeApi', () => ({
+  storeApi: {
+    loadLastUpdateCheckAt: vi.fn().mockResolvedValue(null),
+    saveLastUpdateCheckAt: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock('@tauri-apps/plugin-updater', () => ({}));
 
 import { useUpdateChecker } from '../useUpdateChecker';
 import { updaterApi } from '../../api/updaterApi';
+import { storeApi } from '../../api/storeApi';
 import type { UpdateInfo } from '../../api/updaterApi';
 import { asMock } from '../../test-utils';
+
+const TICK_INTERVAL_MS = 2 * 60 * 60 * 1000;
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 describe('useUpdateChecker', () => {
   let setSnackbar: ReturnType<typeof vi.fn>;
@@ -25,6 +36,16 @@ describe('useUpdateChecker', () => {
   beforeEach(() => {
     setSnackbar = vi.fn();
     vi.clearAllMocks();
+    vi.mocked(updaterApi.checkForUpdate).mockResolvedValue({
+      info: { available: false },
+      update: null,
+    });
+    vi.mocked(storeApi.loadLastUpdateCheckAt).mockResolvedValue(null);
+    vi.mocked(storeApi.saveLastUpdateCheckAt).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   const defaultParams = () => ({
@@ -103,5 +124,153 @@ describe('useUpdateChecker', () => {
     });
 
     expect(result.current.updateDialogOpen).toBe(false);
+  });
+
+  // T-UC-07: saves timestamp on successful check
+  it('T-UC-07: saves timestamp after successful check', async () => {
+    renderHook(() => useUpdateChecker(defaultParams()));
+    await waitFor(() => {
+      expect(storeApi.saveLastUpdateCheckAt).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // T-UC-08: does not save timestamp when check fails
+  it('T-UC-08: does not save timestamp on check failure', async () => {
+    vi.mocked(updaterApi.checkForUpdate).mockRejectedValue(new Error('Network error'));
+
+    renderHook(() => useUpdateChecker(defaultParams()));
+
+    await waitFor(() => {
+      expect(updaterApi.checkForUpdate).toHaveBeenCalled();
+    });
+
+    expect(storeApi.saveLastUpdateCheckAt).not.toHaveBeenCalled();
+  });
+
+  // T-UC-09: tick skips check when last check was less than 24h ago
+  it('T-UC-09: tick skips check within 24h window', async () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    // Pretend last check happened 1 hour ago
+    vi.mocked(storeApi.loadLastUpdateCheckAt).mockResolvedValue(now - 60 * 60 * 1000);
+
+    renderHook(() => useUpdateChecker(defaultParams()));
+
+    // Wait for initial (forced) check to fire
+    await vi.waitFor(() => {
+      expect(updaterApi.checkForUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    // Advance by 2h tick — should NOT trigger another check (within 24h window)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TICK_INTERVAL_MS);
+    });
+
+    expect(updaterApi.checkForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  // T-UC-10: tick triggers check when last check was 24h+ ago
+  it('T-UC-10: tick triggers check after 24h elapsed', async () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    // Initial check uses force=true. After it, timestamp gets set to "now".
+    // We then simulate time passing past the 24h threshold.
+    vi.mocked(storeApi.loadLastUpdateCheckAt).mockImplementation(async () => {
+      // Return the most recent saveLastUpdateCheckAt arg, or null
+      const calls = vi.mocked(storeApi.saveLastUpdateCheckAt).mock.calls;
+      return calls.length > 0 ? (calls[calls.length - 1][0] as number) : null;
+    });
+
+    renderHook(() => useUpdateChecker(defaultParams()));
+
+    await vi.waitFor(() => {
+      expect(updaterApi.checkForUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    // Advance past the 24h threshold (12 ticks of 2h = 24h, plus a bit more)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CHECK_INTERVAL_MS + TICK_INTERVAL_MS);
+    });
+
+    expect(vi.mocked(updaterApi.checkForUpdate).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // T-UC-11: tick triggers check when no previous timestamp exists
+  it('T-UC-11: tick triggers check when timestamp is null', async () => {
+    vi.useFakeTimers();
+    // Make initial check fail so timestamp is never saved
+    vi.mocked(updaterApi.checkForUpdate).mockRejectedValue(new Error('initial fail'));
+    vi.mocked(storeApi.loadLastUpdateCheckAt).mockResolvedValue(null);
+
+    renderHook(() => useUpdateChecker(defaultParams()));
+
+    await vi.waitFor(() => {
+      expect(updaterApi.checkForUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    // Now succeed for the tick call
+    vi.mocked(updaterApi.checkForUpdate).mockResolvedValue({
+      info: { available: false },
+      update: null,
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TICK_INTERVAL_MS);
+    });
+
+    expect(vi.mocked(updaterApi.checkForUpdate).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // T-UC-12: tick is skipped when notification dialog is open
+  it('T-UC-12: tick skipped while update dialog is open', async () => {
+    vi.useFakeTimers();
+    const mockUpdate = { version: '2.0.0' };
+    vi.mocked(updaterApi.checkForUpdate).mockResolvedValue({
+      info: { available: true, version: '2.0.0', body: '' } as UpdateInfo,
+      update: mockUpdate as import('@tauri-apps/plugin-updater').Update,
+    });
+    vi.mocked(storeApi.loadLastUpdateCheckAt).mockResolvedValue(Date.now() - CHECK_INTERVAL_MS - 1000);
+
+    const { result } = renderHook(() => useUpdateChecker(defaultParams()));
+
+    await vi.waitFor(() => {
+      expect(result.current.updateDialogOpen).toBe(true);
+    });
+
+    const callsAfterInitial = vi.mocked(updaterApi.checkForUpdate).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TICK_INTERVAL_MS);
+    });
+
+    // Dialog still open → tick should not have called the API again
+    expect(vi.mocked(updaterApi.checkForUpdate).mock.calls.length).toBe(callsAfterInitial);
+  });
+
+  // T-UC-13: interval is cleaned up when init becomes false
+  it('T-UC-13: stops tick interval when isInitialized becomes false', async () => {
+    vi.useFakeTimers();
+    vi.mocked(storeApi.loadLastUpdateCheckAt).mockResolvedValue(Date.now() - CHECK_INTERVAL_MS - 1000);
+
+    const { rerender } = renderHook(
+      ({ isInitialized }: { isInitialized: boolean }) =>
+        useUpdateChecker({ ...defaultParams(), isInitialized }),
+      { initialProps: { isInitialized: true } },
+    );
+
+    await vi.waitFor(() => {
+      expect(updaterApi.checkForUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ isInitialized: false });
+
+    const callsBefore = vi.mocked(updaterApi.checkForUpdate).mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(TICK_INTERVAL_MS * 3);
+    });
+
+    expect(vi.mocked(updaterApi.checkForUpdate).mock.calls.length).toBe(callsBefore);
   });
 });

--- a/src/hooks/useUpdateChecker.ts
+++ b/src/hooks/useUpdateChecker.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { updaterApi, UpdateInfo, DownloadProgress } from '../api/updaterApi';
+import { storeApi } from '../api/storeApi';
 import { Update } from '@tauri-apps/plugin-updater';
 import { UpdateDialogPhase } from '../components/UpdateDialog';
 
@@ -9,6 +10,9 @@ interface UseUpdateCheckerParams {
   setSnackbar: (snackbar: { open: boolean; message: string; severity: 'success' | 'error' | 'warning' }) => void;
   t: (key: string) => string;
 }
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours between actual server checks
+const TICK_INTERVAL_MS = 2 * 60 * 60 * 1000;   // 2 hours between local timestamp evaluations
 
 export const useUpdateChecker = ({
   isInitialized,
@@ -21,27 +25,53 @@ export const useUpdateChecker = ({
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
   const [updateDownloadProgress, setUpdateDownloadProgress] = useState<DownloadProgress | null>(null);
   const pendingUpdateRef = useRef<Update | null>(null);
+  const updateDialogOpenRef = useRef(false);
 
-  // Auto-check for updates after initialization
+  useEffect(() => {
+    updateDialogOpenRef.current = updateDialogOpen;
+  }, [updateDialogOpen]);
+
+  const performUpdateCheck = useCallback(async (force: boolean) => {
+    // Skip if a notification dialog is already open to avoid duplicate prompts
+    if (updateDialogOpenRef.current) return;
+
+    if (!force) {
+      const lastCheckAt = await storeApi.loadLastUpdateCheckAt();
+      if (lastCheckAt !== null && Date.now() - lastCheckAt < CHECK_INTERVAL_MS) {
+        return;
+      }
+    }
+
+    try {
+      const { info, update } = await updaterApi.checkForUpdate();
+      // Update timestamp only on successful server response
+      await storeApi.saveLastUpdateCheckAt(Date.now());
+
+      if (info.available && update && !updateDialogOpenRef.current) {
+        setUpdateInfo(info);
+        pendingUpdateRef.current = update;
+        setUpdateDialogPhase('notify');
+        setUpdateDialogOpen(true);
+      }
+    } catch (error) {
+      console.warn('Update check failed:', error);
+    }
+  }, []);
+
+  // Auto-check for updates after initialization, then schedule periodic ticks
   useEffect(() => {
     if (!isInitialized || !isSettingsLoaded) return;
 
-    const checkUpdate = async () => {
-      try {
-        const { info, update } = await updaterApi.checkForUpdate();
-        if (info.available && update) {
-          setUpdateInfo(info);
-          pendingUpdateRef.current = update;
-          setUpdateDialogPhase('notify');
-          setUpdateDialogOpen(true);
-        }
-      } catch (error) {
-        console.warn('Update check failed:', error);
-      }
-    };
+    void performUpdateCheck(true);
 
-    checkUpdate();
-  }, [isInitialized, isSettingsLoaded]);
+    const intervalId = window.setInterval(() => {
+      void performUpdateCheck(false);
+    }, TICK_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [isInitialized, isSettingsLoaded, performUpdateCheck]);
 
   const handleCheckForUpdate = useCallback(async () => {
     if (!pendingUpdateRef.current) return;


### PR DESCRIPTION
## Summary

The app previously checked for updates only at startup, so users who keep their PC running (or repeatedly use sleep/wake) without quitting the app could miss new releases. This PR
adds a periodic re-check so long-running sessions also discover updates without needing a restart.

## Changes

- Add a 2-hour `setInterval` tick inside `useUpdateChecker` that evaluates whether 24 hours have elapsed since the last successful server check, and runs an update check when so.
- Persist the last successful update-check timestamp via new `saveLastUpdateCheckAt` / `loadLastUpdateCheckAt` methods on `storeApi` (key: `lastUpdateCheckAt`).
- Update the timestamp only on a successful server response, so transient network failures don't push the next check 24 hours into the future.
- Treat a missing/null timestamp as "24 hours elapsed" so the tick still fires for first-time users.
- Skip the tick when the update notification dialog is already open, preventing duplicate prompts.
- Keep the existing startup check as a forced run that bypasses the 24-hour gate.
- Stop the interval automatically when `isInitialized` or `isSettingsLoaded` flips back to false (cleanup safety).

## Tests

Added 7 new cases to `src/hooks/__tests__/useUpdateChecker.test.ts` (now 13 total), covering:

- Timestamp is saved on successful check (T-UC-07) and not saved on failure (T-UC-08).
- Tick skips the check inside the 24-hour window (T-UC-09), fires after 24 hours have elapsed (T-UC-10), and fires when no prior timestamp exists (T-UC-11).
- Tick is skipped while the update dialog is open (T-UC-12).
- The interval is cleaned up when `isInitialized` becomes false (T-UC-13).

The new tests use `vi.useFakeTimers()` to drive the 2-hour ticks deterministically. All 870 frontend unit tests pass.