### PR TITLE
Inline notice for disabled rendering features (Mermaid / Marp / KaTeX)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ function AppDesktop() {
     // State
     theme,
     settingsOpen,
+    settingsFocusTarget,
     helpOpen,
     recentFilesOpen,
     fileMenuAnchor,
@@ -470,6 +471,7 @@ function AppDesktop() {
             };
             handleAppSettingsChange(updatedSettings);
           }}
+          onOpenSettings={handleSettingsOpen}
           focusRequestId={focusRequestId}
           t={t}
         />
@@ -488,6 +490,7 @@ function AppDesktop() {
           currentZoom={currentZoom}
           ZOOM_CONFIG={ZOOM_CONFIG}
           settingsOpen={settingsOpen}
+          settingsFocusTarget={settingsFocusTarget}
           settings={appSettings}
           helpOpen={helpOpen}
           fileChangeDialog={fileChangeDialog}

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -10,6 +10,7 @@ import { Tab } from '../types/tab';
 import { OutlineDisplayMode } from '../types/outline';
 import { FolderTreeDisplayMode, FolderTreeNode } from '../types/folderTree';
 import { RenderingSettings, ScrollSyncMode } from '../types/settings';
+import type { SettingsFocusTarget } from '../types/settingsFocus';
 import { useOutlineHeadings } from '../hooks/useOutlineHeadings';
 import { useResizableSidebar } from '../hooks/useResizableSidebar';
 import { DRAWER_WIDTH_PX, LAYOUT_SETTLE_DELAY_MS, SIDEBAR_DIVIDER_HEIGHT_PX, SIDEBAR_WIDTH_PX } from '../constants/layout';
@@ -82,6 +83,7 @@ interface AppContentProps {
   onStatusChange: (status: { line: number; column: number; totalCharacters: number; selectedCharacters: number }) => void;
   onSnackbar: (message: string, severity: 'success' | 'error' | 'warning') => void;
   onTableConversionSettingChange?: (newSetting: 'auto' | 'confirm' | 'off') => void;
+  onOpenSettings?: (target?: SettingsFocusTarget) => void;
   focusRequestId?: number;
 
   // Translation
@@ -135,6 +137,7 @@ const AppContent: React.FC<AppContentProps> = ({
   onStatusChange,
   onSnackbar,
   onTableConversionSettingChange,
+  onOpenSettings,
   focusRequestId,
   t,
 }) => {
@@ -437,6 +440,7 @@ const AppContent: React.FC<AppContentProps> = ({
                       filePath={activeTab.filePath}
                       renderingSettings={renderingSettings}
                       viewMode="split"
+                      onOpenSettings={onOpenSettings}
                     />
                   </Box>
                 </>
@@ -489,6 +493,7 @@ const AppContent: React.FC<AppContentProps> = ({
                     scrollFraction={scrollState.source !== 'preview' ? scrollState.fraction : undefined}
                     onScrollChange={handlePreviewScrollChange}
                     viewMode="preview"
+                    onOpenSettings={onOpenSettings}
                   />
                 </Box>
               )}

--- a/src/components/AppDialogs.tsx
+++ b/src/components/AppDialogs.tsx
@@ -7,6 +7,7 @@ import SaveBeforeCloseDialog from './SaveBeforeCloseDialog';
 import UpdateDialog, { UpdateDialogPhase } from './UpdateDialog';
 import WhatsNewDialog from './WhatsNewDialog';
 import { AppSettings } from '../types/settings';
+import { SettingsFocusTarget } from '../types/settingsFocus';
 import { UpdateInfo, DownloadProgress } from '../api/updaterApi';
 
 export interface AppDialogsProps {
@@ -25,6 +26,7 @@ export interface AppDialogsProps {
 
   // Settings dialog state
   settingsOpen: boolean;
+  settingsFocusTarget?: SettingsFocusTarget | null;
   settings: AppSettings;
 
   // Help dialog state
@@ -79,6 +81,7 @@ const AppDialogs: React.FC<AppDialogsProps> = ({
   currentZoom,
   ZOOM_CONFIG,
   settingsOpen,
+  settingsFocusTarget,
   settings,
   helpOpen,
   fileChangeDialog,
@@ -135,6 +138,7 @@ const AppDialogs: React.FC<AppDialogsProps> = ({
         settings={settings}
         onSettingsChange={onSettingsChange}
         as400Unlocked={as400Unlocked}
+        focusTarget={settingsFocusTarget ?? null}
       />
 
       {/* Help dialog */}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -14,6 +14,8 @@ import { buildExportHTML } from '../utils/exportStyles';
 import { contentIsMarp } from '../utils/marpRenderer';
 import { dirnameOf, isAbsoluteUrl, mimeTypeFromPath, resolveRelativePath } from '../utils/imagePathResolver';
 import MarpPreview from './MarpPreview';
+import RenderingFeatureNotice from './RenderingFeatureNotice';
+import { SettingsFocusTarget } from '../types/settingsFocus';
 
 interface PreviewProps {
   content: string;
@@ -27,12 +29,13 @@ interface PreviewProps {
   filePath?: string;
   renderingSettings?: RenderingSettings;
   viewMode?: 'split' | 'editor' | 'preview';
+  onOpenSettings?: (target?: SettingsFocusTarget) => void;
 }
 
 const BASE_PREVIEW_FONT_SIZE_PX = 16;
 const BASE_PREVIEW_LINE_HEIGHT = 1.6;
 
-const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, globalVariables = {}, zoomLevel = 1.0, onContentChange, scrollFraction, onScrollChange, filePath, renderingSettings = DEFAULT_RENDERING_SETTINGS, viewMode = 'split' }) => {
+const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, globalVariables = {}, zoomLevel = 1.0, onContentChange, scrollFraction, onScrollChange, filePath, renderingSettings = DEFAULT_RENDERING_SETTINGS, viewMode = 'split', onOpenSettings }) => {
   const isMarp = renderingSettings.enableMarp && contentIsMarp(content);
   const previewRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -378,6 +381,12 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
           </IconButton>
         </Tooltip>
       </Box>
+      <RenderingFeatureNotice
+        content={content}
+        filePath={filePath}
+        renderingSettings={renderingSettings}
+        onOpenSettings={onOpenSettings}
+      />
       <Box
         ref={scrollContainerRef}
         sx={{

--- a/src/components/RenderingFeatureNotice.tsx
+++ b/src/components/RenderingFeatureNotice.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo, useState } from 'react';
+import { Alert, Button, Box, IconButton, Stack } from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
+import { RenderingSettings } from '../types/settings';
+import { SettingsFocusTarget } from '../types/settingsFocus';
+import { contentHasKatex, contentHasMermaid } from '../utils/markdownRenderers';
+import { contentIsMarp } from '../utils/marpRenderer';
+
+type RenderingFeature = 'mermaid' | 'marp' | 'katex';
+
+interface RenderingFeatureNoticeProps {
+  content: string;
+  filePath?: string;
+  renderingSettings: RenderingSettings;
+  onOpenSettings?: (target?: SettingsFocusTarget) => void;
+}
+
+const STORAGE_KEY = 'bokuchi:renderingNotice:dismissed';
+
+const FEATURE_TO_TARGET: Record<RenderingFeature, SettingsFocusTarget> = {
+  mermaid: 'rendering.enableMermaid',
+  marp: 'rendering.enableMarp',
+  katex: 'rendering.enableKatex',
+};
+
+function loadDismissed(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveDismissed(set: Set<string>): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(set)));
+  } catch {
+    // Ignore storage failures (private mode, quota, etc.)
+  }
+}
+
+const RenderingFeatureNotice: React.FC<RenderingFeatureNoticeProps> = ({
+  content,
+  filePath,
+  renderingSettings,
+  onOpenSettings,
+}) => {
+  const { t } = useTranslation();
+  const [dismissed, setDismissed] = useState<Set<string>>(() => loadDismissed());
+
+  const disabledFeatures = useMemo<RenderingFeature[]>(() => {
+    const result: RenderingFeature[] = [];
+    if (!content) return result;
+    if (!renderingSettings.enableMermaid && contentHasMermaid(content)) result.push('mermaid');
+    if (!renderingSettings.enableMarp && contentIsMarp(content)) result.push('marp');
+    if (!renderingSettings.enableKatex && contentHasKatex(content)) result.push('katex');
+    return result;
+  }, [content, renderingSettings]);
+
+  const dismissKey = `${filePath ?? '__untitled__'}::${disabledFeatures.join(',')}`;
+
+  if (disabledFeatures.length === 0) return null;
+  if (dismissed.has(dismissKey)) return null;
+
+  const featureLabels = disabledFeatures.map((f) => t(`preview.featureNotice.feature.${f}`));
+  const featureList = featureLabels.join(t('preview.featureNotice.separator'));
+
+  const handleClose = () => {
+    const next = new Set(dismissed);
+    next.add(dismissKey);
+    setDismissed(next);
+    saveDismissed(next);
+  };
+
+  const handleOpenSettings = () => {
+    onOpenSettings?.(FEATURE_TO_TARGET[disabledFeatures[0]]);
+  };
+
+  return (
+    <Box sx={{ px: 1, pt: 1 }}>
+      <Alert
+        severity="info"
+        icon={undefined}
+        action={
+          <Stack direction="row" spacing={0.5} alignItems="center" sx={{ flexShrink: 0 }}>
+            {onOpenSettings && (
+              <Button
+                color="inherit"
+                size="small"
+                onClick={handleOpenSettings}
+                sx={{ whiteSpace: 'nowrap' }}
+              >
+                {t('preview.featureNotice.openSettings')}
+              </Button>
+            )}
+            <IconButton
+              size="small"
+              aria-label={t('preview.featureNotice.dismiss')}
+              onClick={handleClose}
+              sx={{ color: 'inherit' }}
+            >
+              <Close fontSize="small" />
+            </IconButton>
+          </Stack>
+        }
+        sx={{ alignItems: 'center' }}
+      >
+        {t('preview.featureNotice.message', { features: featureList })}
+      </Alert>
+    </Box>
+  );
+};
+
+export default RenderingFeatureNotice;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -45,6 +45,11 @@ import { TransitionProps } from '@mui/material/transitions';
 import { Slide } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { AppSettings } from '../types/settings';
+import {
+  SettingsFocusTarget,
+  SETTINGS_FOCUS_TAB_INDEX,
+  SETTINGS_FOCUS_ELEMENT_ID,
+} from '../types/settingsFocus';
 import { storeApi } from '../api/storeApi';
 import { desktopApi } from '../api/desktopApi';
 import { variableApi } from '../api/variableApi';
@@ -56,7 +61,47 @@ interface SettingsProps {
   settings: AppSettings;
   onSettingsChange: (settings: AppSettings) => void;
   as400Unlocked?: boolean;
+  focusTarget?: SettingsFocusTarget | null;
 }
+
+interface RenderingToggleRowProps {
+  target: SettingsFocusTarget;
+  highlighted: boolean;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+  description: string;
+  sx?: object;
+}
+
+const RenderingToggleRow: React.FC<RenderingToggleRowProps> = ({
+  target,
+  highlighted,
+  checked,
+  onChange,
+  label,
+  description,
+  sx,
+}) => (
+  <Box
+    id={SETTINGS_FOCUS_ELEMENT_ID[target]}
+    sx={{
+      p: 1,
+      borderRadius: 1,
+      transition: 'background-color 600ms ease',
+      backgroundColor: highlighted ? 'action.selected' : 'transparent',
+      ...sx,
+    }}
+  >
+    <FormControlLabel
+      control={<Switch checked={checked} onChange={(e) => onChange(e.target.checked)} />}
+      label={label}
+    />
+    <Typography variant="body2" color="text.secondary">
+      {description}
+    </Typography>
+  </Box>
+);
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
@@ -73,10 +118,39 @@ const Settings: React.FC<SettingsProps> = ({
   settings,
   onSettingsChange,
   as400Unlocked,
+  focusTarget,
 }) => {
   const { t } = useTranslation();
   const visibleThemes = getVisibleThemes(as400Unlocked ? ['as400'] : []);
   const [activeTab, setActiveTab] = React.useState(0);
+  const [highlightedTarget, setHighlightedTarget] = React.useState<SettingsFocusTarget | null>(null);
+
+  // Jump to the requested setting when the dialog opens with a focus target.
+  // Switch to the right tab synchronously, then scroll-into-view on the next tick
+  // (the section needs to actually mount before we can find it).
+  React.useEffect(() => {
+    if (!open || !focusTarget) return;
+    setActiveTab(SETTINGS_FOCUS_TAB_INDEX[focusTarget]);
+
+    const elementId = SETTINGS_FOCUS_ELEMENT_ID[focusTarget];
+
+    // Wait for tab content to render, then scroll + highlight
+    const rafId = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = document.getElementById(elementId);
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          setHighlightedTarget(focusTarget);
+        }
+      });
+    });
+
+    const clearId = window.setTimeout(() => setHighlightedTarget(null), 2400);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.clearTimeout(clearId);
+    };
+  }, [open, focusTarget]);
   const [newVariableKey, setNewVariableKey] = React.useState('');
   const [newVariableValue, setNewVariableValue] = React.useState('');
   const [error, setError] = React.useState('');
@@ -1065,42 +1139,32 @@ const Settings: React.FC<SettingsProps> = ({
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                       {t('settings.advanced.renderingDescription')}
                     </Typography>
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={settings.rendering?.enableKatex ?? true}
-                          onChange={(e) => handleSettingChange('rendering', 'enableKatex', e.target.checked)}
-                        />
-                      }
+                    <RenderingToggleRow
+                      target="rendering.enableKatex"
+                      highlighted={highlightedTarget === 'rendering.enableKatex'}
+                      checked={settings.rendering?.enableKatex ?? true}
+                      onChange={(checked) => handleSettingChange('rendering', 'enableKatex', checked)}
                       label={t('settings.advanced.enableKatex')}
+                      description={t('settings.advanced.enableKatexDescription')}
+                      sx={{ mb: 1 }}
                     />
-                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                      {t('settings.advanced.enableKatexDescription')}
-                    </Typography>
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={settings.rendering?.enableMermaid ?? false}
-                          onChange={(e) => handleSettingChange('rendering', 'enableMermaid', e.target.checked)}
-                        />
-                      }
+                    <RenderingToggleRow
+                      target="rendering.enableMermaid"
+                      highlighted={highlightedTarget === 'rendering.enableMermaid'}
+                      checked={settings.rendering?.enableMermaid ?? false}
+                      onChange={(checked) => handleSettingChange('rendering', 'enableMermaid', checked)}
                       label={t('settings.advanced.enableMermaid')}
+                      description={t('settings.advanced.enableMermaidDescription')}
+                      sx={{ mb: 1 }}
                     />
-                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                      {t('settings.advanced.enableMermaidDescription')}
-                    </Typography>
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={settings.rendering?.enableMarp ?? false}
-                          onChange={(e) => handleSettingChange('rendering', 'enableMarp', e.target.checked)}
-                        />
-                      }
+                    <RenderingToggleRow
+                      target="rendering.enableMarp"
+                      highlighted={highlightedTarget === 'rendering.enableMarp'}
+                      checked={settings.rendering?.enableMarp ?? false}
+                      onChange={(checked) => handleSettingChange('rendering', 'enableMarp', checked)}
                       label={t('settings.advanced.enableMarp')}
+                      description={t('settings.advanced.enableMarpDescription')}
                     />
-                    <Typography variant="body2" color="text.secondary">
-                      {t('settings.advanced.enableMarpDescription')}
-                    </Typography>
                   </CardContent>
                 </Card>
 

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -4,6 +4,7 @@ import { useTabsDesktop } from './useTabsDesktop';
 import { useZoom } from './useZoom';
 import { ZOOM_CONFIG } from '../constants/zoom';
 import { Tab } from '../types/tab';
+import { SettingsFocusTarget } from '../types/settingsFocus';
 import { useEditorFocus } from './useEditorFocus';
 import { useFolderTree } from './useFolderTree';
 import { rotateViewMode as rotateViewModeUtil } from '../utils/viewModeUtils';
@@ -30,6 +31,7 @@ export const useAppState = () => {
 
   // UI state (owned by orchestrator)
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsFocusTarget, setSettingsFocusTarget] = useState<SettingsFocusTarget | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
   const [recentFilesOpen, setRecentFilesOpen] = useState(false);
   const [fileMenuAnchor, setFileMenuAnchor] = useState<null | HTMLElement>(null);
@@ -221,8 +223,14 @@ export const useAppState = () => {
     }
   };
 
-  const handleSettingsOpen = () => setSettingsOpen(true);
-  const handleSettingsClose = () => setSettingsOpen(false);
+  const handleSettingsOpen = (target?: SettingsFocusTarget) => {
+    setSettingsFocusTarget(target ?? null);
+    setSettingsOpen(true);
+  };
+  const handleSettingsClose = () => {
+    setSettingsOpen(false);
+    setSettingsFocusTarget(null);
+  };
   const handleHelpOpen = () => setHelpOpen(true);
   const handleHelpClose = () => setHelpOpen(false);
 
@@ -431,6 +439,7 @@ export const useAppState = () => {
     // State
     theme,
     settingsOpen,
+    settingsFocusTarget,
     helpOpen,
     recentFilesOpen,
     fileMenuAnchor,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -559,6 +559,17 @@
     "presentation": "Presentation",
     "previousSlide": "Previous Slide",
     "nextSlide": "Next Slide",
-    "slideCounter": "Slide {{current}} of {{total}}"
+    "slideCounter": "Slide {{current}} of {{total}}",
+    "featureNotice": {
+      "message": "This file uses {{features}}. Enable it in Settings to see it rendered.",
+      "openSettings": "Open Settings",
+      "dismiss": "Dismiss",
+      "separator": ", ",
+      "feature": {
+        "mermaid": "Mermaid",
+        "marp": "Marp",
+        "katex": "KaTeX"
+      }
+    }
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -559,6 +559,17 @@
     "presentation": "プレゼンテーション",
     "previousSlide": "前のスライド",
     "nextSlide": "次のスライド",
-    "slideCounter": "スライド {{current}} / {{total}}"
+    "slideCounter": "スライド {{current}} / {{total}}",
+    "featureNotice": {
+      "message": "このファイルでは {{features}} の記法が使われています。設定でONにするとプレビューに反映されます。",
+      "openSettings": "設定を開く",
+      "dismiss": "閉じる",
+      "separator": "、",
+      "feature": {
+        "mermaid": "Mermaid",
+        "marp": "Marp",
+        "katex": "KaTeX"
+      }
+    }
   }
 }

--- a/src/types/settingsFocus.ts
+++ b/src/types/settingsFocus.ts
@@ -1,0 +1,23 @@
+/**
+ * Targets the Settings dialog can be opened to. Used to deep-link from UI
+ * affordances (e.g. the "this feature is OFF" preview notice) directly to
+ * the relevant toggle.
+ */
+export type SettingsFocusTarget =
+  | 'rendering.enableMermaid'
+  | 'rendering.enableMarp'
+  | 'rendering.enableKatex';
+
+/** Tab index inside the Settings dialog for each focus target. */
+export const SETTINGS_FOCUS_TAB_INDEX: Record<SettingsFocusTarget, number> = {
+  'rendering.enableMermaid': 4,
+  'rendering.enableMarp': 4,
+  'rendering.enableKatex': 4,
+};
+
+/** DOM element id wrapping each focus target's setting row. */
+export const SETTINGS_FOCUS_ELEMENT_ID: Record<SettingsFocusTarget, string> = {
+  'rendering.enableMermaid': 'setting-rendering-enableMermaid',
+  'rendering.enableMarp': 'setting-rendering-enableMarp',
+  'rendering.enableKatex': 'setting-rendering-enableKatex',
+};


### PR DESCRIPTION
## Summary

When a user opens a file that uses Mermaid, Marp, or KaTeX syntax while the corresponding rendering feature is disabled in Settings, an inline info banner now appears above the
preview. This prevents the common confusion of users assuming the editor lacks the feature, by surfacing both the cause and a one-click path to enable it.

## Changes

- Added a new `RenderingFeatureNotice` component shown at the top of the markdown preview when the active document contains syntax for a rendering feature that is currently
disabled. The notice lists the affected features (e.g. "Mermaid"), provides an "Open Settings" action, and an explicit close (×) button. Dismissals are persisted in
`sessionStorage` keyed by file path + feature set so the banner does not re-appear after the user closes it.
- Made the "Open Settings" action deep-link directly to the relevant toggle: it switches the Settings dialog to the Advanced tab and smoothly scrolls the matching switch into
view, then briefly highlights the row so the user can find it at a glance.
- Introduced a shared focus-target registry at `src/types/settingsFocus.ts` (`SettingsFocusTarget` type plus tab-index and DOM-id maps) so the notice, the dialog, and the app
state stay in sync via a single source of truth.
- Threaded a typed `focusTarget` through `useAppState` → `App` → `AppDialogs` → `Settings`, replacing the previous parameter-less open handler. The target is cleared automatically
when the dialog closes.
- Refactored the Advanced tab's three rendering toggles into a small `RenderingToggleRow` helper to remove duplication and to centralise the highlight / id-anchor styling.
- Added i18n keys under `preview.featureNotice.*` in `en.json` and `ja.json`. Other locales fall back to English via the existing `fallbackLng: 'en'` config.
- Detection reuses the existing `contentHasMermaid` / `contentIsMarp` / `contentHasKatex` helpers — no new parsers were added.

## Tests

No test changes.
