### PR TITLE
Fix Marp fullscreen Esc handling and stray Mermaid error overlay

### DIFF
--- a/src/components/MarpPreview.tsx
+++ b/src/components/MarpPreview.tsx
@@ -152,15 +152,17 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
     if (!isSlideMode && !isFullscreen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Don't capture when user is typing in an input/textarea
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-
+      // Esc must always exit fullscreen, even when focus is on Monaco's hidden
+      // textarea (which happens after the OS window exits its own fullscreen).
       if (e.key === 'Escape' && isFullscreen) {
         e.preventDefault();
         setIsFullscreen(false);
         return;
       }
+      // Don't capture other keys when user is typing in an input/textarea
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
       if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
         e.preventDefault();
         goToPrev();
@@ -187,6 +189,9 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
   //   - openExternalUrl: link click inside any slide iframe — must be routed
   //     through the OS browser via the Tauri opener plugin. Direct iframe
   //     navigation would render the linked page inside the slide region.
+  //   - marpKey: keyboard event forwarded from inside the sandboxed slide
+  //     iframe. Sandboxed-iframe keydowns don't bubble to the parent window,
+  //     so the host can never see Esc / arrow keys when the iframe has focus.
   const thumbnailIframeRef = useRef<HTMLIFrameElement>(null);
   useEffect(() => {
     const handleMessage = (e: MessageEvent) => {
@@ -205,10 +210,21 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
         }
         return;
       }
+      if (e.data?.type === 'marpKey' && typeof e.data.key === 'string') {
+        const key = e.data.key;
+        if (key === 'Escape' && isFullscreen) {
+          setIsFullscreen(false);
+        } else if (key === 'ArrowLeft' || key === 'ArrowUp') {
+          goToPrev();
+        } else if (key === 'ArrowRight' || key === 'ArrowDown' || key === ' ') {
+          goToNext();
+        }
+        return;
+      }
     };
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, []);
+  }, [isFullscreen, goToPrev, goToNext]);
 
   // Build iframe srcdoc — for slide mode, build once with initial slide index.
   // Subsequent slide changes are handled via postMessage (no full reload).

--- a/src/utils/markdownRenderers.ts
+++ b/src/utils/markdownRenderers.ts
@@ -48,6 +48,10 @@ async function getMermaid(dark?: boolean) {
         startOnLoad: false,
         theme: dark ? 'dark' : 'default',
         securityLevel: 'strict',
+        // Mermaid 11.14.0 leaks the bomb-icon SVG into document.body on parse
+        // failure (throw happens before removeTempElements). We render our own
+        // error UI in processMermaidBlocks, so suppress Mermaid's built-in one.
+        suppressErrorRendering: true,
       });
       mermaidInitialized = true;
     }
@@ -62,6 +66,7 @@ export function reinitializeMermaid(dark: boolean) {
       startOnLoad: false,
       theme: dark ? 'dark' : 'default',
       securityLevel: 'strict',
+      suppressErrorRendering: true,
     });
   }
 }

--- a/src/utils/marpRenderer.ts
+++ b/src/utils/marpRenderer.ts
@@ -85,6 +85,21 @@ export const LINK_INTERCEPTOR_SCRIPT = `
   }
   document.addEventListener('click', handleClick, true);
   document.addEventListener('auxclick', handleClick, true);
+
+  // Forward keyboard navigation to the host. The iframe is sandboxed, so
+  // keydown events fired inside it never bubble to the parent window. The
+  // host listens for { type: 'marpKey', key } and routes to fullscreen exit /
+  // slide navigation.
+  function handleKey(e) {
+    var k = e.key;
+    if (k !== 'Escape' && k !== 'ArrowLeft' && k !== 'ArrowRight'
+        && k !== 'ArrowUp' && k !== 'ArrowDown' && k !== ' ') return;
+    e.preventDefault();
+    try {
+      window.parent.postMessage({ type: 'marpKey', key: k }, '*');
+    } catch (err) {}
+  }
+  document.addEventListener('keydown', handleKey, true);
 })();
 `;
 


### PR DESCRIPTION
## Summary

Fixes two bugs surfaced while presenting in Marp mode: Esc no longer exited Marp fullscreen once focus was inside the sandboxed slide iframe (or had returned to Monaco's hidden
textarea after the OS window left fullscreen), and a Mermaid "Syntax error in text" bomb icon could appear at the bottom of the screen in OS fullscreen. The Esc issue is resolved
by forwarding keystrokes from the slide iframe via postMessage and reordering the host-side handler; the Mermaid artifact is resolved by enabling `suppressErrorRendering`.

## Changes

- Forward `Escape`, arrow keys, and `Space` from inside the sandboxed Marp slide iframe to the host via `postMessage({ type: 'marpKey', key })`, since sandboxed-iframe keydowns
never bubble to the parent window.
- Handle `marpKey` messages in `MarpPreview` to exit fullscreen on `Esc` and navigate slides on arrows/`Space`, regardless of which element holds focus.
- Reorder the host-level keydown handler so `Esc` exits fullscreen even when focus is on Monaco's hidden textarea (which can happen after the OS window leaves its own fullscreen).
- Initialize Mermaid with `suppressErrorRendering: true` so parse failures no longer leak the bomb-icon SVG into `document.body` (a Mermaid 11.14.0 bug where the throw happens
before `removeTempElements`); the app already renders its own error UI in `processMermaidBlocks`.

## Tests

No test changes.