### PR TITLE
Show a file path tooltip when hovering over a tab

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -16,7 +16,7 @@ import {
 import { Close, Add, PushPin } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { Tab as TabType } from '../types/tab';
-import { getTabDisplayTitle } from '../utils/pathUtils';
+import { getTabDisplayTitle, formatFilePathForDisplay } from '../utils/pathUtils';
 import {
   DndContext,
   closestCenter,
@@ -110,6 +110,13 @@ const SortableTab: React.FC<{
 
   const isLeft = closeButtonPosition === 'left';
 
+  // File path tooltip text — empty string disables the tooltip in MUI.
+  // Unsaved/new tabs may have no real on-disk path even when filePath is set,
+  // matching the same condition used by the "Copy file path" menu item.
+  const filePathTooltip = tab.filePath && !tab.isNew
+    ? formatFilePathForDisplay(tab.filePath)
+    : '';
+
   // Close/Pin button element for vertical layout
   const verticalActionButton = tab.isPinned ? (
     <PushPin fontSize="small" sx={{ [isLeft ? 'mr' : 'ml']: 1, flexShrink: 0, opacity: 0.7, color: isActive ? 'inherit' : 'primary.main' }} />
@@ -133,67 +140,69 @@ const SortableTab: React.FC<{
 
   if (layout === 'vertical') {
     return (
-      <ListItem
-        ref={mergedRef}
-        style={style}
-        disablePadding
-        sx={{
-          opacity: isDragging ? 0.5 : 1,
-        }}
-      >
-        <ListItemButton
-          selected={isActive}
-          onClick={() => onClick(tab.id)}
-          onDoubleClick={() => onDoubleClick?.(tab.id)}
-          onContextMenu={(e) => onContextMenu?.(e, tab.id)}
+      <Tooltip title={filePathTooltip} followCursor placement="bottom-start" enterDelay={300}>
+        <ListItem
+          ref={mergedRef}
+          style={style}
+          disablePadding
           sx={{
-            py: 1,
-            px: 2,
-            '&.Mui-selected': {
-              bgcolor: 'primary.main',
-              color: 'primary.contrastText',
-              '&:hover': {
-                bgcolor: 'primary.dark',
-              },
-            },
+            opacity: isDragging ? 0.5 : 1,
           }}
         >
-          {isLeft && verticalActionButton}
-          <Box
-            {...attributes}
-            {...listeners}
+          <ListItemButton
+            selected={isActive}
+            onClick={() => onClick(tab.id)}
+            onDoubleClick={() => onDoubleClick?.(tab.id)}
+            onContextMenu={(e) => onContextMenu?.(e, tab.id)}
             sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              cursor: 'grab',
-              minWidth: 0,
-              '&:active': {
-                cursor: 'grabbing',
+              py: 1,
+              px: 2,
+              '&.Mui-selected': {
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
+                '&:hover': {
+                  bgcolor: 'primary.dark',
+                },
               },
             }}
           >
+            {isLeft && verticalActionButton}
             <Box
+              {...attributes}
+              {...listeners}
               sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                fontSize: '0.875rem',
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                cursor: 'grab',
                 minWidth: 0,
+                '&:active': {
+                  cursor: 'grabbing',
+                },
               }}
             >
-              {getTabDisplayTitle(tab)}
+              <Box
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: '0.875rem',
+                  minWidth: 0,
+                }}
+              >
+                {getTabDisplayTitle(tab)}
+              </Box>
+              <Badge
+                color="error"
+                variant="dot"
+                invisible={!tab.isModified}
+                sx={{ ml: 1, flexShrink: 0 }}
+              />
             </Box>
-            <Badge
-              color="error"
-              variant="dot"
-              invisible={!tab.isModified}
-              sx={{ ml: 1, flexShrink: 0 }}
-            />
-          </Box>
-          {!isLeft && verticalActionButton}
-        </ListItemButton>
-      </ListItem>
+            {!isLeft && verticalActionButton}
+          </ListItemButton>
+        </ListItem>
+      </Tooltip>
     );
   }
 
@@ -233,70 +242,72 @@ const SortableTab: React.FC<{
   );
 
   return (
-    <Tab
-      ref={setNodeRef}
-      style={style}
-      value={tab.id}
-      onClick={() => onClick(tab.id)}
-      onDoubleClick={() => onDoubleClick?.(tab.id)}
-      onContextMenu={(e) => onContextMenu?.(e, tab.id)}
-      label={
-        <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', minWidth: 0 }}>
-          {isLeft && horizontalActionButton}
-          <Box
-            {...attributes}
-            {...listeners}
-            sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              cursor: 'grab',
-              minWidth: 0,
-              '&:active': {
-                cursor: 'grabbing',
-              },
-            }}
-          >
+    <Tooltip title={filePathTooltip} followCursor placement="bottom-start" enterDelay={300}>
+      <Tab
+        ref={setNodeRef}
+        style={style}
+        value={tab.id}
+        onClick={() => onClick(tab.id)}
+        onDoubleClick={() => onDoubleClick?.(tab.id)}
+        onContextMenu={(e) => onContextMenu?.(e, tab.id)}
+        label={
+          <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', minWidth: 0 }}>
+            {isLeft && horizontalActionButton}
             <Box
+              {...attributes}
+              {...listeners}
               sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                cursor: 'grab',
                 minWidth: 0,
+                '&:active': {
+                  cursor: 'grabbing',
+                },
               }}
             >
-              {getTabDisplayTitle(tab)}
+              <Box
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
+                }}
+              >
+                {getTabDisplayTitle(tab)}
+              </Box>
+              <Badge
+                color="error"
+                variant="dot"
+                invisible={!tab.isModified}
+                sx={{ ml: 1, flexShrink: 0 }}
+              />
             </Box>
-            <Badge
-              color="error"
-              variant="dot"
-              invisible={!tab.isModified}
-              sx={{ ml: 1, flexShrink: 0 }}
-            />
+            {!isLeft && horizontalActionButton}
           </Box>
-          {!isLeft && horizontalActionButton}
-        </Box>
-      }
-      sx={{
-        '& .MuiTab-iconWrapper': {
-          display: 'none',
-        },
-        borderTop: '3px solid',
-        borderTopColor: tab.isPinned && !isActive ? 'primary.main' : 'transparent',
-        ...(isActive && {
-          bgcolor: 'primary.main',
-          color: 'primary.contrastText',
-          '&:hover': {
-            bgcolor: 'primary.dark',
+        }
+        sx={{
+          '& .MuiTab-iconWrapper': {
+            display: 'none',
           },
-        }),
-        ...(!isActive && {
-          '&:hover': {
-            bgcolor: 'action.hover',
-          },
-        }),
-      }}
-    />
+          borderTop: '3px solid',
+          borderTopColor: tab.isPinned && !isActive ? 'primary.main' : 'transparent',
+          ...(isActive && {
+            bgcolor: 'primary.main',
+            color: 'primary.contrastText',
+            '&:hover': {
+              bgcolor: 'primary.dark',
+            },
+          }),
+          ...(!isActive && {
+            '&:hover': {
+              bgcolor: 'action.hover',
+            },
+          }),
+        }}
+      />
+    </Tooltip>
   );
 };
 

--- a/src/utils/__tests__/pathUtils.test.ts
+++ b/src/utils/__tests__/pathUtils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   normalizeFilePath,
   extractFileNameFromPath,
@@ -6,7 +6,9 @@ import {
   checkDuplicateFileInTabs,
   isMarkdownFile,
   getTabDisplayTitle,
+  formatFilePathForDisplay,
 } from '../pathUtils';
+import * as platform from '../platform';
 import type { Tab } from '../../types/tab';
 
 describe('normalizeFilePath', () => {
@@ -161,6 +163,42 @@ describe('isMarkdownFile', () => {
   it('T-PU-22: returns false for similar but non-markdown extensions', () => {
     expect(isMarkdownFile('file.mdx')).toBe(false);
     expect(isMarkdownFile('file.mdown')).toBe(false);
+  });
+});
+
+describe('formatFilePathForDisplay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // T-PU-29: Windows displays with backslashes
+  it('T-PU-29: converts forward slashes to backslashes on Windows', () => {
+    vi.spyOn(platform, 'getPlatform').mockReturnValue('windows');
+    expect(formatFilePathForDisplay('C:/Users/foo/file.md')).toBe('C:\\Users\\foo\\file.md');
+  });
+
+  // T-PU-30: Windows leaves backslash paths unchanged
+  it('T-PU-30: keeps native backslash paths unchanged on Windows', () => {
+    vi.spyOn(platform, 'getPlatform').mockReturnValue('windows');
+    expect(formatFilePathForDisplay('C:\\Users\\foo\\file.md')).toBe('C:\\Users\\foo\\file.md');
+  });
+
+  // T-PU-31: macOS displays with forward slashes
+  it('T-PU-31: converts backslashes to forward slashes on macOS', () => {
+    vi.spyOn(platform, 'getPlatform').mockReturnValue('mac');
+    expect(formatFilePathForDisplay('\\Users\\foo\\file.md')).toBe('/Users/foo/file.md');
+  });
+
+  // T-PU-32: macOS leaves native forward-slash paths unchanged
+  it('T-PU-32: keeps native forward-slash paths unchanged on macOS', () => {
+    vi.spyOn(platform, 'getPlatform').mockReturnValue('mac');
+    expect(formatFilePathForDisplay('/Users/foo/file.md')).toBe('/Users/foo/file.md');
+  });
+
+  // T-PU-33: Linux behaves like macOS
+  it('T-PU-33: uses forward slashes on Linux', () => {
+    vi.spyOn(platform, 'getPlatform').mockReturnValue('linux');
+    expect(formatFilePathForDisplay('/home/user/file.md')).toBe('/home/user/file.md');
   });
 });
 

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -1,9 +1,22 @@
 import { Tab } from '../types/tab';
+import { getPlatform } from './platform';
 
 /**
  * Normalize file path by replacing backslashes with forward slashes.
  */
 export const normalizeFilePath = (filePath: string): string => {
+  return filePath.replace(/\\/g, '/');
+};
+
+/**
+ * Format a file path for display using the current OS's native separator.
+ * Windows displays with backslashes; macOS/Linux with forward slashes.
+ * This guards against paths that were stored on a different OS.
+ */
+export const formatFilePathForDisplay = (filePath: string): string => {
+  if (getPlatform() === 'windows') {
+    return filePath.replace(/\//g, '\\');
+  }
   return filePath.replace(/\\/g, '/');
 };
 


### PR DESCRIPTION
## Summary
- Show a tooltip with the file's full path when the user hovers over a tab.
- The tooltip follows the cursor and triggers anywhere on the tab (not just the title text), in both horizontal and vertical tab layouts.
- The path is rendered with the OS-native separator: backslashes on Windows, forward slashes on macOS/Linux. This guards against paths persisted on a different OS.
- New/unsaved tabs (no real on-disk path) intentionally show no tooltip, matching the existing rule used by the "Copy file path" context-menu item.