### PR TITLE
Fix code block rendering: drop auto language detection and improve Darcula contrast

### DIFF
--- a/src/styles/syntax.css
+++ b/src/styles/syntax.css
@@ -310,7 +310,7 @@
 
 /* Darcula theme specific overrides */
 [data-theme="darcula"] .markdown-preview pre {
-  background-color: #2B2B2B !important;
+  background-color: #3C3F41 !important;
   border: 1px solid #323232 !important;
   color: #A9B7C6 !important;
 }
@@ -328,7 +328,7 @@
 }
 
 [data-theme="darcula"] .hljs {
-  background-color: #2B2B2B !important;
+  background-color: #3C3F41 !important;
   color: #A9B7C6 !important;
   border: none !important;
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -140,7 +140,7 @@
 
   --color-code-background: #3c3f41;
   --color-code-text: #cc7832;
-  --color-pre-background: #2b2b2b;
+  --color-pre-background: #3c3f41;
   --color-pre-text: #a9b7c6;
 
   --color-syntax-comment: #808080;

--- a/src/utils/__tests__/markdownRenderers.test.ts
+++ b/src/utils/__tests__/markdownRenderers.test.ts
@@ -60,18 +60,30 @@ describe('renderCode', () => {
     expect(result).toContain('<highlighted');
   });
 
-  it('falls back to auto-highlight for unknown languages', () => {
-    const result = renderCode({ text: 'some code', lang: 'unknown-lang' });
+  it('does not auto-highlight unknown languages (escapes HTML and emits plain)', async () => {
+    const hljs = (await import('highlight.js')).default;
+    const autoSpy = vi.mocked(hljs.highlightAuto);
+    autoSpy.mockClear();
+
+    const result = renderCode({ text: 'a < b & c', lang: 'unknown-lang' });
     expect(result).toContain('hljs');
     expect(result).toContain('language-unknown-lang');
-    expect(result).toContain('<auto-highlighted>');
+    expect(result).not.toContain('<auto-highlighted>');
+    expect(result).toContain('a &lt; b &amp; c');
+    expect(autoSpy).not.toHaveBeenCalled();
   });
 
-  it('falls back to auto-highlight when no language specified', () => {
-    const result = renderCode({ text: 'some code' });
+  it('does not auto-highlight when no language specified (escapes HTML and emits plain)', async () => {
+    const hljs = (await import('highlight.js')).default;
+    const autoSpy = vi.mocked(hljs.highlightAuto);
+    autoSpy.mockClear();
+
+    const result = renderCode({ text: 'a < b & c' });
     expect(result).toContain('hljs');
-    expect(result).toContain('<auto-highlighted>');
     expect(result).not.toContain('language-');
+    expect(result).not.toContain('<auto-highlighted>');
+    expect(result).toContain('a &lt; b &amp; c');
+    expect(autoSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/markdownRenderers.ts
+++ b/src/utils/markdownRenderers.ts
@@ -22,9 +22,12 @@ export function renderCode({ text, lang }: { text: string; lang?: string; escape
       console.warn('Highlight.js error:', err);
     }
   }
+  // No language (or unknown language): do not auto-detect. Emit plain,
+  // HTML-escaped code so the user's intent (unspecified = no highlighting)
+  // is respected.
+  const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   const langClass = lang ? ` language-${lang}` : '';
-  const highlighted = hljs.highlightAuto(text).value;
-  return `<pre><code class="hljs${langClass}">${highlighted}</code></pre>`;
+  return `<pre><code class="hljs${langClass}">${escaped}</code></pre>`;
 }
 
 // Lazy-loaded module caches


### PR DESCRIPTION
## Summary

Two preview-side fixes for fenced code blocks:

1. Stop auto-detecting the language when the user did not specify one. Previously, hljs.highlightAuto() would guess a language and apply syntax highlighting even for unmarked blocks,
which produced inconsistent and misleading coloring (e.g. terminal output partly colored as Bash, INI-like text colored as TOML). Now the renderer honors the user's intent: no language
tag means no highlighting.
2. Fix the Darcula theme where the code block background (#2b2b2b) was identical to the page background, making code blocks visually indistinguishable from surrounding text. The code
block background is now #3c3f41, matching the existing surface / inline-code color so the block reads as a code surface.

Syntax highlighting colors are unchanged.

## Changes

- src/utils/markdownRenderers.ts — Removed the hljs.highlightAuto() fallback. When no language is specified (or the language is unknown to highlight.js), the renderer now emits
HTML-escaped plain text inside `<pre><code class="hljs">`. The .hljs class is kept so the code-block surface styling (background, padding, monospace) still applies.
- src/styles/variables.css — Darcula --color-pre-background: #2b2b2b → #3c3f41.
- src/styles/syntax.css — Darcula hard-coded overrides for .markdown-preview pre and .hljs: #2B2B2B → #3C3F41.

## Test

- src/utils/__tests__/markdownRenderers.test.ts — Replaced the two "falls back to auto-highlight" cases with assertions that:
- hljs.highlightAuto is not invoked when no language or an unknown language is given.
- The output contains the expected .hljs / language-* classes.
- Special characters (<, &) are HTML-escaped in the emitted output.