### PR TITLE
group interdependent dependencies in Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,36 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    # 相互依存するパッケージ群をまとめて1つのPRに集約し、
+    # バージョン不整合によるCI失敗を防ぐ
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      mui:
+        patterns:
+          - "@mui/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vite-plugin-*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      testing-library:
+        patterns:
+          - "@testing-library/*"
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
     ignore:
       # メジャーバージョンアップは手動で確認
       - dependency-name: "*"


### PR DESCRIPTION
## Summary

Configure Dependabot to consolidate tightly-coupled package families into a single PR per group. Previously, packages whose versions must move together (e.g. react / react-dom) were
updated in separate PRs, which produced version mismatches and broke CI until both PRs were merged.

## Changes

- .github/dependabot.yml — Added a groups: block to the npm ecosystem update. Seven groups are defined, each bundling related packages:
- react: react, react-dom, @types/react, @types/react-dom
- mui: @mui/*
- typescript-eslint: @typescript-eslint/*
- vite: vite, @vitejs/*, vite-plugin-*
- vitest: vitest, @vitest/*
- testing-library: @testing-library/*
- tauri: @tauri-apps/*

Existing settings (weekly schedule, major-version ignore, labels, reviewers) are preserved. Cargo and GitHub Actions sections are unchanged.