### PR TITLE
Fix Mermaid not rendering in Marp slide mode

### DIFF
--- a/src/components/MarpPreview.tsx
+++ b/src/components/MarpPreview.tsx
@@ -7,6 +7,7 @@ import { variableApi } from '../api/variableApi';
 import { renderMarp, buildSlideDocument, buildAllSlidesDocument, buildThumbnailDocument } from '../utils/marpRenderer';
 import { inlineMarpRelativeImages } from '../utils/marpImageInliner';
 import { computeSlideLineRanges, scrollFractionToSlidePosition } from '../utils/marpSlideRanges';
+import { contentHasMermaid, processMermaidBlocks, reinitializeMermaid } from '../utils/markdownRenderers';
 
 interface MarpPreviewProps {
   content: string;
@@ -25,6 +26,8 @@ const SLIDE_COUNTER_MIN_WIDTH_PX = 60;
 
 const MarpPreview: React.FC<MarpPreviewProps> = ({
   content,
+  darkMode,
+  theme,
   globalVariables = {},
   scrollFraction,
   filePath,
@@ -56,7 +59,8 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
         return;
       }
 
-      const inputKey = content + JSON.stringify(globalVariables) + (filePath || '');
+      const isDark = darkMode || theme === 'darcula';
+      const inputKey = content + JSON.stringify(globalVariables) + (filePath || '') + String(isDark);
       if (inputKey === lastInputRef.current) return;
 
       const result = await variableApi.processMarkdown(content, globalVariables);
@@ -64,6 +68,19 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
 
       let { html, css, slideCount: count } = await renderMarp(result.processedContent);
       if (stale) return;
+
+      // Render mermaid code blocks to inline SVG. marp-core has no built-in
+      // mermaid support, so without this step ```mermaid fences emit raw
+      // <pre><code> in the slide HTML (the bug we're fixing here).
+      if (contentHasMermaid(result.processedContent)) {
+        try {
+          reinitializeMermaid(isDark);
+          html = await processMermaidBlocks(html, isDark);
+        } catch (err) {
+          console.warn('[MarpPreview] Mermaid processing failed:', err);
+        }
+        if (stale) return;
+      }
 
       // Inline relative images as data URLs so the iframe can display them
       if (filePath) {
@@ -84,7 +101,7 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
 
     process();
     return () => { stale = true; };
-  }, [content, globalVariables, filePath]);
+  }, [content, globalVariables, filePath, darkMode, theme]);
 
   // Compute slide line ranges from source content (memoized)
   const slideRanges = React.useMemo(() => computeSlideLineRanges(content), [content]);

--- a/src/utils/markdownRenderers.ts
+++ b/src/utils/markdownRenderers.ts
@@ -167,7 +167,9 @@ async function processMermaidBlocksInternal(html: string, dark?: boolean): Promi
 
   // Find mermaid diagram placeholders in the HTML
   // After marked processes ```mermaid blocks, they become <pre><code class="...mermaid...">
-  const mermaidHtmlRe = /<pre><code class="[^"]*(?:language-mermaid|mermaid)[^"]*">([\s\S]*?)<\/code><\/pre>/g;
+  // Marp emits <pre is="marp-pre" data-auto-scaling="..."><code class="language-mermaid">,
+  // so allow attributes on <pre> (matches both forms).
+  const mermaidHtmlRe = /<pre[^>]*><code class="[^"]*(?:language-mermaid|mermaid)[^"]*">([\s\S]*?)<\/code><\/pre>/g;
 
   const matches: { full: string; code: string }[] = [];
   let match;

--- a/src/utils/marpRenderer.ts
+++ b/src/utils/marpRenderer.ts
@@ -151,6 +151,22 @@ div.marpit {
     height: 100%;
   }
 }
+
+/* Mermaid diagrams rendered inside slides */
+.mermaid-diagram {
+  display: flex;
+  justify-content: center;
+  margin: 0.5em 0;
+  max-width: 100%;
+}
+.mermaid-diagram svg {
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+}
+.mermaid-error {
+  margin: 0.5em 0;
+}
 </style>
 </head>
 <body>${html}
@@ -249,6 +265,22 @@ div.marpit {
   display: block;
   width: 100%;
   height: auto;
+}
+
+/* Mermaid diagrams rendered inside slides */
+.mermaid-diagram {
+  display: flex;
+  justify-content: center;
+  margin: 0.5em 0;
+  max-width: 100%;
+}
+.mermaid-diagram svg {
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+}
+.mermaid-error {
+  margin: 0.5em 0;
 }
 
 .slide-number {
@@ -361,6 +393,22 @@ div.marpit > svg[data-marpit-svg] {
 div.marpit {
   padding: 0 16px;
   box-sizing: border-box;
+}
+
+/* Mermaid diagrams rendered inside slides */
+.mermaid-diagram {
+  display: flex;
+  justify-content: center;
+  margin: 0.5em 0;
+  max-width: 100%;
+}
+.mermaid-diagram svg {
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+}
+.mermaid-error {
+  margin: 0.5em 0;
 }
 </style>
 </head>


### PR DESCRIPTION
## Summary

Mermaid code blocks were rendered as raw `<pre><code>` text inside Marp slides because the Marp render pipeline never ran the mermaid post-processor, and the post-processor's
regex would not have matched Marp's `<pre is="marp-pre">` markup even if invoked. This PR wires mermaid processing into the Marp path and broadens the regex so both code paths
render diagrams consistently.

## Changes

- Run `processMermaidBlocks` on the HTML returned by `renderMarp` in `MarpPreview`, reusing the same lazy-loaded mermaid pipeline as the regular preview (dark-mode aware,
serialized via the existing lock, with the existing error UI).
- Plumb `darkMode` / `theme` into `MarpPreview`, include them in the render cache key, and add them to the render effect's dependency array so theme switches re-render diagrams.
- Relax the mermaid-block regex in `markdownRenderers.ts` from `<pre><code …>` to `<pre[^>]*><code …>` so it matches Marp's `<pre is="marp-pre" data-auto-scaling="…">` output in
addition to the plain `<pre>` emitted by `marked`.
- Add `.mermaid-diagram` / `.mermaid-error` sizing CSS to all three Marp iframe srcdoc builders (`buildSlideDocument`, `buildThumbnailDocument`, `buildAllSlidesDocument`) so
rendered SVGs are constrained to the slide area.

## Tests

No test changes. Verified the existing Vitest suite (889 tests) still passes, and confirmed against actual `@marp-team/marp-core` output that the relaxed regex matches the `<pre
is="marp-pre">` form.