### PR TITLE
Prompt for unsaved tabs in batch close operations

### DIFF
--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -169,6 +169,7 @@ export const useAppState = () => {
     handleSaveBeforeClose,
     handleDontSaveBeforeClose,
     handleCancelBeforeClose,
+    startCloseQueue,
   } = useFileOperations({
     activeTab,
     tabs,
@@ -320,34 +321,42 @@ export const useAppState = () => {
   }, [tabs, t]);
 
   const handleCloseOtherTabs = useCallback((tabId: string) => {
-    const idsToClose = tabs
-      .filter(tab => tab.id !== tabId && !tab.isPinned && !tab.isModified)
-      .map(tab => tab.id);
-    if (idsToClose.length > 0) {
-      removeTabs(idsToClose);
+    const targets = tabs.filter(tab => tab.id !== tabId && !tab.isPinned);
+    const cleanIds = targets.filter(tab => !tab.isModified).map(tab => tab.id);
+    const dirtyIds = targets.filter(tab => tab.isModified).map(tab => tab.id);
+    if (cleanIds.length > 0) {
+      removeTabs(cleanIds);
     }
-  }, [tabs, removeTabs]);
+    if (dirtyIds.length > 0) {
+      startCloseQueue(dirtyIds);
+    }
+  }, [tabs, removeTabs, startCloseQueue]);
 
   const handleCloseTabsToRight = useCallback((tabId: string) => {
     const tabIndex = tabs.findIndex(t => t.id === tabId);
     if (tabIndex === -1) return;
-    const idsToClose = tabs
-      .slice(tabIndex + 1)
-      .filter(tab => !tab.isPinned && !tab.isModified)
-      .map(tab => tab.id);
-    if (idsToClose.length > 0) {
-      removeTabs(idsToClose);
+    const targets = tabs.slice(tabIndex + 1).filter(tab => !tab.isPinned);
+    const cleanIds = targets.filter(tab => !tab.isModified).map(tab => tab.id);
+    const dirtyIds = targets.filter(tab => tab.isModified).map(tab => tab.id);
+    if (cleanIds.length > 0) {
+      removeTabs(cleanIds);
     }
-  }, [tabs, removeTabs]);
+    if (dirtyIds.length > 0) {
+      startCloseQueue(dirtyIds);
+    }
+  }, [tabs, removeTabs, startCloseQueue]);
 
   const handleCloseAllTabs = useCallback(() => {
-    const idsToClose = tabs
-      .filter(tab => !tab.isPinned && !tab.isModified)
-      .map(tab => tab.id);
-    if (idsToClose.length > 0) {
-      removeTabs(idsToClose);
+    const targets = tabs.filter(tab => !tab.isPinned);
+    const cleanIds = targets.filter(tab => !tab.isModified).map(tab => tab.id);
+    const dirtyIds = targets.filter(tab => tab.isModified).map(tab => tab.id);
+    if (cleanIds.length > 0) {
+      removeTabs(cleanIds);
     }
-  }, [tabs, removeTabs]);
+    if (dirtyIds.length > 0) {
+      startCloseQueue(dirtyIds);
+    }
+  }, [tabs, removeTabs, startCloseQueue]);
 
   const handleFolderTreeFileClick = useCallback(async (filePath: string) => {
     try {

--- a/src/hooks/useFileOperations.ts
+++ b/src/hooks/useFileOperations.ts
@@ -34,10 +34,12 @@ export const useFileOperations = ({
     open: boolean;
     fileName: string;
     tabId: string | null;
+    queue: Array<{ tabId: string; fileName: string }>;
   }>({
     open: false,
     fileName: '',
     tabId: null,
+    queue: [],
   });
   const [isDragOver, setIsDragOver] = useState(false);
 
@@ -112,6 +114,38 @@ export const useFileOperations = ({
     }
   }, [activeTab, globalVariables, setSnackbar, showSaveStatus, t]);
 
+  const advanceCloseQueue = useCallback(() => {
+    setSaveBeforeCloseDialog(prev => {
+      if (prev.queue.length === 0) {
+        return { open: false, fileName: '', tabId: null, queue: [] };
+      }
+      const [next, ...rest] = prev.queue;
+      return {
+        open: true,
+        fileName: next.fileName,
+        tabId: next.tabId,
+        queue: rest,
+      };
+    });
+  }, []);
+
+  const startCloseQueue = useCallback((tabIds: string[]) => {
+    const items = tabIds
+      .map(id => {
+        const tab = tabs.find(entry => entry.id === id);
+        return tab ? { tabId: id, fileName: tab.title } : null;
+      })
+      .filter((item): item is { tabId: string; fileName: string } => item !== null);
+    if (items.length === 0) return;
+    const [first, ...rest] = items;
+    setSaveBeforeCloseDialog({
+      open: true,
+      fileName: first.fileName,
+      tabId: first.tabId,
+      queue: rest,
+    });
+  }, [tabs]);
+
   const handleTabClose = (tabId: string) => {
     const tab = tabs.find(entry => entry.id === tabId);
     if (!tab) return;
@@ -121,6 +155,7 @@ export const useFileOperations = ({
         open: true,
         fileName: tab.title,
         tabId: tabId,
+        queue: [],
       });
     } else {
       removeTab(tabId);
@@ -129,18 +164,19 @@ export const useFileOperations = ({
 
   const handleSaveBeforeClose = async () => {
     if (!saveBeforeCloseDialog.tabId) return;
+    const targetTabId = saveBeforeCloseDialog.tabId;
 
     try {
-      const success = await saveTab(saveBeforeCloseDialog.tabId);
+      const success = await saveTab(targetTabId);
       if (success) {
-        removeTab(saveBeforeCloseDialog.tabId);
+        removeTab(targetTabId);
         showSaveStatus(t('statusBar.saved'));
       }
     } catch (error) {
       console.error('Failed to save file before closing:', error);
       setSnackbar({ open: true, message: t('fileOperations.fileSaveFailed'), severity: 'error' });
     } finally {
-      setSaveBeforeCloseDialog({ open: false, fileName: '', tabId: null });
+      advanceCloseQueue();
     }
   };
 
@@ -148,11 +184,11 @@ export const useFileOperations = ({
     if (saveBeforeCloseDialog.tabId) {
       removeTab(saveBeforeCloseDialog.tabId);
     }
-    setSaveBeforeCloseDialog({ open: false, fileName: '', tabId: null });
+    advanceCloseQueue();
   };
 
   const handleCancelBeforeClose = () => {
-    setSaveBeforeCloseDialog({ open: false, fileName: '', tabId: null });
+    advanceCloseQueue();
   };
 
   return {
@@ -168,5 +204,6 @@ export const useFileOperations = ({
     handleSaveBeforeClose,
     handleDontSaveBeforeClose,
     handleCancelBeforeClose,
+    startCloseQueue,
   };
 };


### PR DESCRIPTION
## Summary

Previously, batch tab close operations ("Close Others", "Close to the Right", "Close All") silently skipped tabs with unsaved changes. This PR changes the behavior to queue those
unsaved tabs and prompt the user via the existing save-before-close dialog one by one, so no modified tab is dropped without confirmation.

## Changes

- Added a queue field to the save-before-close dialog state in useFileOperations to track pending unsaved tabs awaiting confirmation.
- Introduced startCloseQueue to kick off the prompt sequence and advanceCloseQueue to advance through the queue after each Save / Don't Save / Cancel action.
- Updated handleCloseOtherTabs, handleCloseTabsToRight, and handleCloseAllTabs in useAppState to close clean tabs immediately and feed the dirty tabs into the new dialog queue.

## Tests

No test changes.