### PR TITLE
Fix crash when typing `<!-- @var -->` in editor

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -32,6 +32,7 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 
 use tauri::Emitter;
@@ -71,18 +72,27 @@ pub fn export_variables_to_yaml() -> Result<String, String> {
 }
 
 // Tauri command: Process Markdown (variable expansion)
+//
+// Wrapped in catch_unwind because this is invoked on every keystroke in the
+// editor — a panic here previously killed the whole Tauri main process. We
+// would rather surface the panic as a command error and keep the editor alive
+// than have the app exit in the middle of someone's edit.
 #[tauri::command]
 pub fn process_markdown(
     content: String,
     global_variables: HashMap<String, String>,
 ) -> Result<String, String> {
-    // Temporarily set global variables
-    for (name, value) in global_variables {
-        VARIABLE_PROCESSOR.set_global_variable(name, value);
-    }
-
-    let result = VARIABLE_PROCESSOR.process_variables(&content);
-    Ok(result)
+    catch_unwind(AssertUnwindSafe(|| {
+        for (name, value) in global_variables {
+            VARIABLE_PROCESSOR.set_global_variable(name, value);
+        }
+        VARIABLE_PROCESSOR.process_variables(&content)
+    }))
+    .map_err(|panic_payload| {
+        let msg = panic_message(&panic_payload);
+        eprintln!("[process_markdown] panic caught: {}", msg);
+        format!("process_markdown panicked: {}", msg)
+    })
 }
 
 // Tauri command: Get expanded Markdown content
@@ -91,13 +101,30 @@ pub fn get_expanded_markdown(
     content: String,
     global_variables: HashMap<String, String>,
 ) -> Result<String, String> {
-    // Temporarily set global variables
-    for (name, value) in global_variables {
-        VARIABLE_PROCESSOR.set_global_variable(name, value);
-    }
+    catch_unwind(AssertUnwindSafe(|| {
+        for (name, value) in global_variables {
+            VARIABLE_PROCESSOR.set_global_variable(name, value);
+        }
+        VARIABLE_PROCESSOR.process_variables(&content)
+    }))
+    .map_err(|panic_payload| {
+        let msg = panic_message(&panic_payload);
+        eprintln!("[get_expanded_markdown] panic caught: {}", msg);
+        format!("get_expanded_markdown panicked: {}", msg)
+    })
+}
 
-    let result = VARIABLE_PROCESSOR.process_variables(&content);
-    Ok(result)
+// Extract a printable message from a panic payload. Panics carry their payload
+// as `Box<dyn Any + Send>`; the standard library only formats &str and String
+// variants, so we mirror that and fall back to a placeholder.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
 }
 
 // Tauri command: Read file

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -421,6 +421,57 @@ fn test_process_variables_empty_content() {
     assert_eq!(result, "");
 }
 
+// R-VP-16b: regression — `<!-- @var -->` must not panic.
+// The prefix `<!-- @var ` and suffix ` -->` share the same space character in
+// this input, so stripping the prefix first leaves `-->` (3 bytes) which is
+// shorter than the ` -->` (4-byte) suffix. The previous implementation called
+// `.strip_suffix(...).unwrap()` and crashed the Tauri main process, taking the
+// app down on every keystroke that produced this exact comment.
+#[test]
+fn test_parse_empty_var_comment_does_not_panic() {
+    let processor = VariableProcessor::new();
+    let content = "<!-- @var -->\nSome text";
+    let (variables, processed_content) = processor.parse_variables_from_markdown(content);
+    assert_eq!(variables.len(), 0);
+    assert!(processed_content.contains("Some text"));
+}
+
+// R-VP-16c: process_variables must not panic on the same input. This is the
+// entry point invoked by the `process_markdown` Tauri command on every edit.
+#[test]
+fn test_process_variables_with_empty_var_comment_does_not_panic() {
+    let processor = VariableProcessor::new();
+    let result = processor.process_variables("<!-- @var -->");
+    // Either result is acceptable as long as we don't panic; this just
+    // documents the current behavior so changes are caught explicitly.
+    let _ = result;
+}
+
+// R-VP-16d: incremental keystrokes leading up to `<!-- @var -->` must all be
+// processable. This mirrors the live editor flow where MarpPreview invokes
+// process_markdown on every edit.
+#[test]
+fn test_parse_var_comment_incremental_keystrokes() {
+    let processor = VariableProcessor::new();
+    let stages = [
+        "<!---->",
+        "<!-- -->",
+        "<!--  -->",
+        "<!-- @ -->",
+        "<!-- @v -->",
+        "<!-- @va -->",
+        "<!-- @var -->",
+        "<!-- @var  -->",
+        "<!-- @var n -->",
+        "<!-- @var n: -->",
+        "<!-- @var n: v -->",
+    ];
+    for stage in stages {
+        let (_variables, _processed) = processor.parse_variables_from_markdown(stage);
+        let _ = processor.process_variables(stage);
+    }
+}
+
 // R-VP-17
 #[test]
 fn test_yaml_invalid_format() {

--- a/src-tauri/src/variable_processor.rs
+++ b/src-tauri/src/variable_processor.rs
@@ -61,17 +61,23 @@ impl VariableProcessor {
         let lines: Vec<&str> = content.lines().collect();
         let mut processed_lines = Vec::new();
 
+        const VAR_PREFIX: &str = "<!-- @var ";
+        const VAR_SUFFIX: &str = " -->";
+
         for line in lines {
             let trimmed = line.trim();
 
-            // Check for variable definition pattern
-            if trimmed.starts_with("<!-- @var ") && trimmed.ends_with(" -->") {
+            // Check for variable definition pattern. The length guard prevents
+            // a panic for inputs like `<!-- @var -->`, where the trailing space
+            // of the prefix and the leading space of the suffix are the same
+            // character — stripping the prefix would leave a string shorter
+            // than the suffix, so the previous `.unwrap()` chain crashed.
+            if trimmed.starts_with(VAR_PREFIX)
+                && trimmed.ends_with(VAR_SUFFIX)
+                && trimmed.len() >= VAR_PREFIX.len() + VAR_SUFFIX.len()
+            {
                 // <!-- @var name: value --> format
-                let var_content = trimmed
-                    .strip_prefix("<!-- @var ")
-                    .unwrap()
-                    .strip_suffix(" -->")
-                    .unwrap();
+                let var_content = &trimmed[VAR_PREFIX.len()..trimmed.len() - VAR_SUFFIX.len()];
 
                 if let Some(colon_index) = var_content.find(':') {
                     let name = var_content[..colon_index].trim().to_string();


### PR DESCRIPTION
## Summary

Fixes a critical bug where typing the exact HTML comment `<!-- @var -->` killed the Tauri main process and terminated the app on every keystroke that produced this string (easy to
hit while editing Marp slides). The `parse_variables_from_markdown` parser stripped a prefix and suffix that shared a single space character, then called `.unwrap()` on the
resulting `None`, panicking the `process_markdown` command that the preview invokes on every edit.

## Changes

- Replace the unsafe `strip_prefix(...).unwrap().strip_suffix(...).unwrap()` chain in `parse_variables_from_markdown` with a length-guarded byte slice that correctly handles
inputs where the prefix and suffix overlap (e.g. `<!-- @var -->`).
- Wrap `process_markdown` and `get_expanded_markdown` in `std::panic::catch_unwind` so any future Rust-side panic in these per-keystroke commands is surfaced as a command error
and logged to stderr instead of bringing the whole app down.

## Tests

- `test_parse_empty_var_comment_does_not_panic`: regression test for the exact failing input `<!-- @var -->`.
- `test_process_variables_with_empty_var_comment_does_not_panic`: ensures the public `process_variables` entry point used by the Tauri command is also safe.
- `test_parse_var_comment_incremental_keystrokes`: walks through every intermediate state produced by the reported keystroke sequence (`<!---->` through `<!-- @var n: v -->`) to
guard against similar overlap regressions.