### PR TITLE
Add four new themes — Dawn / Twilight / Silk / Ink (with localized display names)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import StatusBar from './components/StatusBar';
 import RecentFilesDialog from './components/RecentFilesDialog';
 import RenameDialog from './components/RenameDialog';
 import { useAppState } from './hooks/useAppState';
+import { isDarkTheme } from './themes';
 import './i18n';
 import './styles/variables.css';
 import './styles/base.css';
@@ -535,7 +536,7 @@ function AppDesktop() {
         column={editorStatus.column}
         totalCharacters={editorStatus.totalCharacters}
         selectedCharacters={editorStatus.selectedCharacters}
-        darkMode={theme === 'dark' || theme === 'as400'}
+        darkMode={isDarkTheme(theme)}
         theme={theme}
         onThemeChange={handleThemeChange}
         zoomPercentage={zoomPercentage}

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -14,6 +14,7 @@ import type { SettingsFocusTarget } from '../types/settingsFocus';
 import { useOutlineHeadings } from '../hooks/useOutlineHeadings';
 import { useResizableSidebar } from '../hooks/useResizableSidebar';
 import { DRAWER_WIDTH_PX, LAYOUT_SETTLE_DELAY_MS, SIDEBAR_DIVIDER_HEIGHT_PX, SIDEBAR_WIDTH_PX } from '../constants/layout';
+import { isDarkTheme, ThemeName } from '../themes';
 
 interface AppContentProps {
   // State
@@ -401,7 +402,7 @@ const AppContent: React.FC<AppContentProps> = ({
                     <Editor
                       content={activeTab.content}
                       onChange={onContentChange}
-                      darkMode={theme === 'dark' || theme === 'as400'}
+                      darkMode={isDarkTheme(theme as ThemeName)}
                       theme={theme}
                       onStatusChange={onStatusChange}
                       zoomLevel={currentZoom}
@@ -434,7 +435,7 @@ const AppContent: React.FC<AppContentProps> = ({
                   <Box sx={{ flex: 1, minWidth: 0, overflow: 'hidden', borderLeft: 1, borderColor: 'divider', boxSizing: 'border-box' }}>
                     <Preview
                       content={activeTab.content}
-                      darkMode={theme === 'dark' || theme === 'as400'}
+                      darkMode={isDarkTheme(theme as ThemeName)}
                       theme={theme}
                       globalVariables={globalVariables}
                       zoomLevel={currentZoom}
@@ -455,7 +456,7 @@ const AppContent: React.FC<AppContentProps> = ({
                   <Editor
                     content={activeTab.content}
                     onChange={onContentChange}
-                    darkMode={theme === 'dark' || theme === 'as400'}
+                    darkMode={isDarkTheme(theme as ThemeName)}
                     theme={theme}
                     onStatusChange={onStatusChange}
                     zoomLevel={currentZoom}
@@ -488,7 +489,7 @@ const AppContent: React.FC<AppContentProps> = ({
                 <Box sx={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
                   <Preview
                     content={activeTab.content}
-                    darkMode={theme === 'dark' || theme === 'as400'}
+                    darkMode={isDarkTheme(theme as ThemeName)}
                     theme={theme}
                     globalVariables={globalVariables}
                     zoomLevel={currentZoom}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -51,7 +51,6 @@ const MarkdownEditor: React.FC<EditorProps> = ({
   content,
   onChange,
   darkMode,
-  theme,
   fileNotFound,
   onStatusChange,
   zoomLevel = 1.0,
@@ -629,7 +628,7 @@ const MarkdownEditor: React.FC<EditorProps> = ({
             defaultValue={content}
             onChange={handleEditorChange}
             onMount={handleEditorDidMount}
-            theme={theme === 'darcula' ? 'vs-dark' : (darkMode ? 'vs-dark' : 'light')}
+            theme={darkMode ? 'vs-dark' : 'light'}
             options={{
               minimap: { enabled: minimap },
               fontSize: Math.round(fontSize * zoomLevel),

--- a/src/components/MarpPreview.tsx
+++ b/src/components/MarpPreview.tsx
@@ -27,7 +27,6 @@ const SLIDE_COUNTER_MIN_WIDTH_PX = 60;
 const MarpPreview: React.FC<MarpPreviewProps> = ({
   content,
   darkMode,
-  theme,
   globalVariables = {},
   scrollFraction,
   filePath,
@@ -59,7 +58,7 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
         return;
       }
 
-      const isDark = darkMode || theme === 'darcula';
+      const isDark = darkMode;
       const inputKey = content + JSON.stringify(globalVariables) + (filePath || '') + String(isDark);
       if (inputKey === lastInputRef.current) return;
 
@@ -101,7 +100,7 @@ const MarpPreview: React.FC<MarpPreviewProps> = ({
 
     process();
     return () => { stale = true; };
-  }, [content, globalVariables, filePath, darkMode, theme]);
+  }, [content, globalVariables, filePath, darkMode]);
 
   // Compute slide line ranges from source content (memoized)
   const slideRanges = React.useMemo(() => computeSlideLineRanges(content), [content]);

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { marked } from 'marked';
 import { Box, Typography, IconButton, Tooltip, Snackbar, Alert } from '@mui/material';
+import { useTheme, alpha } from '@mui/material/styles';
 import { Download } from '@mui/icons-material';
 import 'highlight.js/styles/github.css';
 import 'highlight.js/styles/github-dark.css';
@@ -37,6 +38,8 @@ const BASE_PREVIEW_FONT_SIZE_PX = 16;
 const BASE_PREVIEW_LINE_HEIGHT = 1.6;
 
 const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, globalVariables = {}, zoomLevel = 1.0, onContentChange, scrollFraction, onScrollChange, filePath, renderingSettings = DEFAULT_RENDERING_SETTINGS, previewSettings = DEFAULT_PREVIEW_SETTINGS, viewMode = 'split', onOpenSettings }) => {
+  const muiTheme = useTheme();
+  const { palette } = muiTheme;
   const isMarp = renderingSettings.enableMarp && contentIsMarp(content);
   const previewRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -124,9 +127,8 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
         // Process Mermaid diagrams (lazy-loaded, after marked parsing)
         if (renderingSettings.enableMermaid && contentHasMermaid(processedMarkdown)) {
           try {
-            const isDark = darkMode || theme === 'darcula';
-            reinitializeMermaid(isDark);
-            processedHtml = await processMermaidBlocks(processedHtml, isDark);
+            reinitializeMermaid(darkMode);
+            processedHtml = await processMermaidBlocks(processedHtml, darkMode);
           } catch (err) {
             console.warn('Mermaid processing failed, showing raw code blocks:', err);
           }
@@ -346,7 +348,7 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
 
       // Process Mermaid diagrams for export (renders as inline SVG)
       if (renderingSettings.enableMermaid && contentHasMermaid(processedContent)) {
-        exportHtml = await processMermaidBlocks(exportHtml, darkMode || theme === 'darcula');
+        exportHtml = await processMermaidBlocks(exportHtml, darkMode);
       }
 
       const fullHTML = buildExportHTML(exportHtml, darkMode, theme, previewSettings.tableLayout);
@@ -394,8 +396,8 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
           flex: 1,
           p: 2,
           overflow: 'auto',
-          backgroundColor: theme === 'as400' ? '#000000' : theme === 'darcula' ? '#2B2B2B' : (darkMode ? 'grey.900' : 'grey.50'),
-          color: theme === 'as400' ? '#00FF00' : theme === 'darcula' ? '#A9B7C6' : (darkMode ? 'grey.100' : 'text.primary'),
+          backgroundColor: palette.background.default,
+          color: palette.text.primary,
           ...(theme === 'as400' ? {
             background: 'repeating-linear-gradient(0deg, #000000 0px, #000000 4px, rgba(0,255,0,0.2) 4px, rgba(0,255,0,0.2) 5px)',
           } : {}),
@@ -403,7 +405,7 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
       >
         <div
           ref={previewRef}
-          className={`markdown-preview ${theme === 'darcula' ? 'hljs-dark' : (darkMode ? 'hljs-dark' : 'hljs-light')}`}
+          className={`markdown-preview ${darkMode ? 'hljs-dark' : 'hljs-light'}`}
           dangerouslySetInnerHTML={{ __html: htmlContent }}
           style={{
             fontSize: `${Math.round(BASE_PREVIEW_FONT_SIZE_PX * zoomLevel)}px`,
@@ -463,13 +465,13 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
 
             .markdown-preview h1 {
               font-size: 2em;
-              border-bottom: 1px solid ${theme === 'darcula' ? '#404040' : (darkMode ? '#404040' : '#eaecef')};
+              border-bottom: 1px solid ${palette.divider};
               padding-bottom: 0.3em;
             }
 
             .markdown-preview h2 {
               font-size: 1.5em;
-              border-bottom: 1px solid ${theme === 'darcula' ? '#404040' : (darkMode ? '#404040' : '#eaecef')};
+              border-bottom: 1px solid ${palette.divider};
               padding-bottom: 0.3em;
             }
 
@@ -488,14 +490,14 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
             }
 
             .markdown-preview blockquote {
-              border-left: 4px solid ${theme === 'darcula' ? '#404040' : (darkMode ? '#404040' : '#dfe2e5')};
+              border-left: 4px solid ${palette.divider};
               padding-left: 1em;
               margin: 1em 0;
-              color: ${theme === 'darcula' ? '#a0a0a0' : (darkMode ? '#a0a0a0' : '#6a737d')};
+              color: ${palette.text.secondary};
             }
 
             .markdown-preview code {
-              background-color: ${theme === 'darcula' ? 'rgba(255,255,255,0.1)' : (darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(27,31,35,0.05)')};
+              background-color: ${alpha(palette.text.primary, 0.08)};
               padding: 0.2em 0.4em;
               border-radius: 3px;
               font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
@@ -504,7 +506,7 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
             }
 
                         .markdown-preview pre {
-              background-color: ${theme === 'darcula' ? '#2d2d2d' : (darkMode ? '#2d2d2d' : '#f6f8fa')};
+              background-color: var(--color-pre-background);
               border-radius: 3px;
               padding: 16px;
               overflow: auto;
@@ -527,12 +529,12 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
             ${generateTableLayoutCSS(
               previewSettings.tableLayout,
               '.markdown-preview ',
-              theme === 'darcula' ? '#404040' : (darkMode ? '#404040' : '#dfe2e5'),
-              theme === 'darcula' ? '#2d2d2d' : (darkMode ? '#2d2d2d' : '#f6f8fa'),
+              'var(--color-border)',
+              'var(--color-pre-background)',
             )}
 
             .markdown-preview a {
-              color: ${theme === 'darcula' ? '#58a6ff' : (darkMode ? '#58a6ff' : '#0366d6')};
+              color: ${palette.primary.main};
               text-decoration: none;
             }
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -490,7 +490,7 @@ const Settings: React.FC<SettingsProps> = ({
                       >
                         {visibleThemes.map((themeOption) => (
                           <MenuItem key={themeOption.name} value={themeOption.name}>
-                            {themeOption.displayName}
+                            {t(`settings.appearance.themes.${themeOption.name}`, themeOption.displayName)}
                           </MenuItem>
                         ))}
                       </Select>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Typography, Menu, MenuItem, IconButton, Tooltip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { ZoomIn, ZoomOut, RestartAlt } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { ThemeName, getVisibleThemes } from '../themes';
@@ -9,7 +10,7 @@ interface StatusBarProps {
   column: number;
   totalCharacters: number;
   selectedCharacters: number;
-  darkMode: boolean;
+  darkMode?: boolean;
   theme?: string;
   onThemeChange?: (theme: ThemeName) => void;
   zoomPercentage: number;
@@ -28,7 +29,6 @@ const StatusBar: React.FC<StatusBarProps> = ({
   column,
   totalCharacters,
   selectedCharacters,
-  darkMode,
   theme,
   onThemeChange,
   zoomPercentage,
@@ -42,6 +42,8 @@ const StatusBar: React.FC<StatusBarProps> = ({
   saveStatusMessage
 }) => {
   const { t } = useTranslation();
+  const muiTheme = useTheme();
+  const { palette } = muiTheme;
   const [themeMenuAnchor, setThemeMenuAnchor] = useState<null | HTMLElement>(null);
   const visibleThemes = getVisibleThemes(as400Unlocked ? ['as400'] : []);
 
@@ -64,14 +66,14 @@ const StatusBar: React.FC<StatusBarProps> = ({
       className="status-bar"
       sx={{
         height: '24px',
-        backgroundColor: theme === 'as400' ? '#001a00' : theme === 'darcula' ? '#3C3F41' : (darkMode ? '#1e1e1e' : '#f3f3f3'),
+        backgroundColor: palette.background.paper,
         borderTop: 1,
-        borderColor: theme === 'as400' ? '#003300' : theme === 'darcula' ? '#323232' : 'divider',
+        borderColor: palette.divider,
         display: 'flex',
         alignItems: 'center',
         px: 2,
         fontSize: '12px',
-        color: theme === 'as400' ? '#00FF00' : theme === 'darcula' ? '#A9B7C6' : (darkMode ? '#cccccc' : '#666666'),
+        color: palette.text.secondary,
         fontFamily: 'monospace'
       }}
     >
@@ -105,7 +107,7 @@ const StatusBar: React.FC<StatusBarProps> = ({
               minWidth: 'auto',
               opacity: canZoomOut ? 1 : 0.5,
               '&:hover': {
-                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                backgroundColor: palette.action.hover,
               }
             }}
           >
@@ -136,7 +138,7 @@ const StatusBar: React.FC<StatusBarProps> = ({
               minWidth: 'auto',
               opacity: canZoomIn ? 1 : 0.5,
               '&:hover': {
-                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                backgroundColor: palette.action.hover,
               }
             }}
           >
@@ -153,7 +155,7 @@ const StatusBar: React.FC<StatusBarProps> = ({
               padding: '2px',
               minWidth: 'auto',
               '&:hover': {
-                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                backgroundColor: palette.action.hover,
               }
             }}
           >
@@ -188,12 +190,12 @@ const StatusBar: React.FC<StatusBarProps> = ({
             padding: '2px 8px',
             minWidth: 'auto',
             '&:hover': {
-              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              backgroundColor: palette.action.hover,
             }
           }}
         >
           <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-            {theme ? visibleThemes.find(t => t.name === theme)?.displayName || 'Default' : 'Default'}
+            {theme ? t(`settings.appearance.themes.${theme}`, visibleThemes.find(tc => tc.name === theme)?.displayName || 'Default') : 'Default'}
           </Typography>
         </IconButton>
 
@@ -211,8 +213,8 @@ const StatusBar: React.FC<StatusBarProps> = ({
           }}
           PaperProps={{
             sx: {
-              backgroundColor: theme === 'as400' ? '#0a0a0a' : theme === 'darcula' ? '#3C3F41' : (darkMode ? '#1e1e1e' : '#ffffff'),
-              border: theme === 'as400' ? '1px solid #003300' : theme === 'darcula' ? '1px solid #323232' : (darkMode ? '1px solid #404040' : '1px solid #e0e0e0'),
+              backgroundColor: palette.background.paper,
+              border: `1px solid ${palette.divider}`,
               minWidth: '120px',
             }
           }}
@@ -222,23 +224,23 @@ const StatusBar: React.FC<StatusBarProps> = ({
               key={themeOption.name}
               onClick={() => handleThemeSelect(themeOption.name)}
               sx={{
-                color: theme === 'as400' ? '#00FF00' : theme === 'darcula' ? '#A9B7C6' : (darkMode ? '#cccccc' : '#333333'),
+                color: palette.text.primary,
                 fontSize: '12px',
                 padding: '4px 12px',
                 '&:hover': {
-                  backgroundColor: theme === 'as400' ? '#003300' : theme === 'darcula' ? '#4C4F51' : (darkMode ? '#2d2d2d' : '#f5f5f5'),
+                  backgroundColor: palette.action.hover,
                 },
                 '&.Mui-selected': {
-                  backgroundColor: theme === 'as400' ? '#00FF00' : theme === 'darcula' ? '#CC7832' : (darkMode ? '#007acc' : '#e3f2fd'),
-                  color: theme === 'as400' ? '#000000' : theme === 'darcula' ? '#2B2B2B' : (darkMode ? '#ffffff' : '#1976d2'),
+                  backgroundColor: palette.primary.main,
+                  color: palette.primary.contrastText,
                   '&:hover': {
-                    backgroundColor: theme === 'as400' ? '#33FF33' : theme === 'darcula' ? '#D18F4A' : (darkMode ? '#005a9e' : '#bbdefb'),
+                    backgroundColor: palette.primary.dark,
                   }
                 }
               }}
               selected={theme === themeOption.name}
             >
-              {themeOption.displayName}
+              {t(`settings.appearance.themes.${themeOption.name}`, themeOption.displayName)}
             </MenuItem>
           ))}
         </Menu>

--- a/src/components/__tests__/Editor.test.tsx
+++ b/src/components/__tests__/Editor.test.tsx
@@ -218,9 +218,9 @@ describe('MarkdownEditor', () => {
   // =========================================================================
 
   describe('settings propagation', () => {
-    // T-ED-04: theme selection
+    // T-ED-04: darcula passed with darkMode true sets vs-dark
     it('T-ED-04: darcula theme sets vs-dark', () => {
-      render(<MarkdownEditor {...defaultProps()} theme="darcula" />);
+      render(<MarkdownEditor {...defaultProps()} theme="darcula" darkMode={true} />);
       expect(screen.getByTestId('monaco-editor').dataset.theme).toBe('vs-dark');
     });
 

--- a/src/components/__tests__/Preview.test.tsx
+++ b/src/components/__tests__/Preview.test.tsx
@@ -397,11 +397,11 @@ describe('MarkdownPreview – themes', () => {
     expect(preview?.classList.contains('hljs-light')).toBe(true);
   });
 
-  // T-PV-12: darcula theme overrides to hljs-dark
-  it('T-PV-12: darcula theme forces hljs-dark class', async () => {
+  // T-PV-12: darcula passed with darkMode=true uses hljs-dark
+  it('T-PV-12: darcula theme uses hljs-dark class', async () => {
     const { container } = await renderPreviewContent({
       content: 'Darcula content',
-      darkMode: false,
+      darkMode: true,
       theme: 'darcula',
     });
 

--- a/src/components/__tests__/StatusBar.test.tsx
+++ b/src/components/__tests__/StatusBar.test.tsx
@@ -3,7 +3,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, defaultValue?: string) => defaultValue ?? key,
   }),
 }));
 

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -257,11 +257,15 @@
       "theme": "السمة",
       "themeDescription": "اختر السمة البصرية لواجهة التطبيق.",
       "themes": {
-        "default": "افتراضي",
-        "dark": "داكن",
-        "pastel": "باستيل",
-        "vivid": "حيوي",
-        "darcula": "داركولا"
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
+        "darcula": "Darcula"
       }
     },
     "globalVariables": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -257,10 +257,14 @@
       "theme": "Theme",
       "themeDescription": "Wählen Sie das visuelle Theme für die Anwendungsoberfläche.",
       "themes": {
-        "default": "Standard",
-        "dark": "Dunkel",
-        "pastel": "Pastell",
-        "vivid": "Lebhaft",
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
         "darcula": "Darcula"
       }
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -261,6 +261,10 @@
         "dark": "Dark",
         "pastel": "Pastel",
         "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
         "darcula": "Darcula"
       }
     },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -257,10 +257,14 @@
       "theme": "Tema",
       "themeDescription": "Elige el tema visual para la interfaz de la aplicación.",
       "themes": {
-        "default": "Predeterminado",
-        "dark": "Oscuro",
+        "default": "Default",
+        "dark": "Dark",
         "pastel": "Pastel",
-        "vivid": "Vívido",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
         "darcula": "Darcula"
       }
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -257,10 +257,14 @@
       "theme": "Thème",
       "themeDescription": "Choisissez le thème visuel pour l'interface de l'application.",
       "themes": {
-        "default": "Par défaut",
-        "dark": "Sombre",
+        "default": "Default",
+        "dark": "Dark",
         "pastel": "Pastel",
-        "vivid": "Vif",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
         "darcula": "Darcula"
       }
     },

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -257,11 +257,15 @@
       "theme": "थीम",
       "themeDescription": "एप्लिकेशन इंटरफेस के लिए दृश्य थीम चुनें।",
       "themes": {
-        "default": "डिफ़ॉल्ट",
-        "dark": "डार्क",
-        "pastel": "पेस्टल",
-        "vivid": "विविड",
-        "darcula": "डार्कुला"
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
+        "darcula": "Darcula"
       }
     },
     "globalVariables": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -258,9 +258,13 @@
       "themeDescription": "Pilih tema visual untuk antarmuka aplikasi.",
       "themes": {
         "default": "Default",
-        "dark": "Gelap",
+        "dark": "Dark",
         "pastel": "Pastel",
-        "vivid": "Hidup",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
         "darcula": "Darcula"
       }
     },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -257,11 +257,15 @@
       "theme": "テーマ",
       "themeDescription": "アプリケーションの視覚テーマが選択できます。",
       "themes": {
-        "default": "デフォルト",
-        "dark": "ダーク",
-        "pastel": "パステル",
-        "vivid": "ビビッド",
-        "darcula": "ダーキュラ"
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "暁",
+        "twilight": "黄昏",
+        "silk": "絹",
+        "ink": "墨",
+        "darcula": "Darcula"
       }
     },
     "globalVariables": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -257,11 +257,15 @@
       "theme": "테마",
       "themeDescription": "애플리케이션 인터페이스의 시각적 테마를 선택하세요.",
       "themes": {
-        "default": "기본값",
-        "dark": "다크",
-        "pastel": "파스텔",
-        "vivid": "생생한",
-        "darcula": "다큘라"
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
+        "darcula": "Darcula"
       }
     },
     "globalVariables": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -257,10 +257,14 @@
       "theme": "Tema",
       "themeDescription": "Escolha o tema visual para a interface da aplicação.",
       "themes": {
-        "default": "Padrão",
-        "dark": "Escuro",
+        "default": "Default",
+        "dark": "Dark",
         "pastel": "Pastel",
-        "vivid": "Vívido",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
         "darcula": "Darcula"
       }
     },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -257,11 +257,15 @@
       "theme": "Тема",
       "themeDescription": "Выберите визуальную тему для интерфейса приложения.",
       "themes": {
-        "default": "По умолчанию",
-        "dark": "Темная",
-        "pastel": "Пастельная",
-        "vivid": "Яркая",
-        "darcula": "Даркула"
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
+        "darcula": "Darcula"
       }
     },
     "globalVariables": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -257,10 +257,14 @@
       "theme": "Chủ đề",
       "themeDescription": "Chọn chủ đề trực quan cho giao diện ứng dụng.",
       "themes": {
-        "default": "Mặc định",
-        "dark": "Tối",
+        "default": "Default",
+        "dark": "Dark",
         "pastel": "Pastel",
-        "vivid": "Sống động",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
         "darcula": "Darcula"
       }
     },

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -257,11 +257,15 @@
       "theme": "主题",
       "themeDescription": "选择应用程序界面的视觉主题。",
       "themes": {
-        "default": "默认",
-        "dark": "深色",
-        "pastel": "柔和",
-        "vivid": "鲜艳",
-        "darcula": "达库拉"
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
+        "darcula": "Darcula"
       }
     },
     "globalVariables": {

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -257,11 +257,15 @@
       "theme": "主題",
       "themeDescription": "選擇應用程式介面的視覺主題。",
       "themes": {
-        "default": "預設",
-        "dark": "深色",
-        "pastel": "柔和",
-        "vivid": "鮮豔",
-        "darcula": "達庫拉"
+        "default": "Default",
+        "dark": "Dark",
+        "pastel": "Pastel",
+        "vivid": "Vivid",
+        "dawn": "Dawn",
+        "twilight": "Twilight",
+        "silk": "Silk",
+        "ink": "Ink",
+        "darcula": "Darcula"
       }
     },
     "globalVariables": {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -134,14 +134,20 @@
 }
 
 /* ダークテーマ用のチェックボックススタイル */
-[data-theme="dark"] .markdown-preview .checkbox-item:hover {
+[data-theme="dark"] .markdown-preview .checkbox-item:hover,
+[data-theme="twilight"] .markdown-preview .checkbox-item:hover,
+[data-theme="ink"] .markdown-preview .checkbox-item:hover {
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-[data-theme="dark"] .markdown-preview .checkbox-item.checked:hover {
+[data-theme="dark"] .markdown-preview .checkbox-item.checked:hover,
+[data-theme="twilight"] .markdown-preview .checkbox-item.checked:hover,
+[data-theme="ink"] .markdown-preview .checkbox-item.checked:hover {
   background-color: rgba(25, 118, 210, 0.25);
 }
 
-[data-theme="dark"] .markdown-preview .markdown-checkbox {
+[data-theme="dark"] .markdown-preview .markdown-checkbox,
+[data-theme="twilight"] .markdown-preview .markdown-checkbox,
+[data-theme="ink"] .markdown-preview .markdown-checkbox {
   accent-color: #42a5f5;
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -160,6 +160,138 @@
   --color-status-text: #808080;
 }
 
+/* Dawn theme (Akatsuki - Light with warm terracotta tint) */
+[data-theme="dawn"] {
+  --color-primary: #785e4f;
+  --color-primary-hover: #5e483b;
+  --color-background: #faf6f4;
+  --color-surface: #f4edea;
+  --color-text: #39312d;
+  --color-text-secondary: #796b64;
+  --color-border: #e6dad2;
+  --color-border-light: #ede4dd;
+
+  --color-code-background: rgba(57, 49, 45, 0.08);
+  --color-code-text: #39312d;
+  --color-pre-background: #f4edea;
+  --color-pre-text: #39312d;
+
+  --color-syntax-comment: #796b64;
+  --color-syntax-keyword: #d73a49;
+  --color-syntax-string: #032f62;
+  --color-syntax-number: #005cc5;
+  --color-syntax-function: #6f42c1;
+  --color-syntax-variable: #e36209;
+  --color-syntax-type: #005cc5;
+
+  --color-search-highlight: #ffeb3b;
+  --color-search-highlight-text: #000000;
+  --color-search-current-highlight: #ff9800;
+  --color-search-current-highlight-text: #000000;
+
+  --color-status-background: #f4edea;
+  --color-status-text: #796b64;
+}
+
+/* Twilight theme (Tasogare - Dark with warm gold tint) */
+[data-theme="twilight"] {
+  --color-primary: #c8be9c;
+  --color-primary-hover: #b3a987;
+  --color-background: #25231d;
+  --color-surface: #2d2a23;
+  --color-text: #e0dccc;
+  --color-text-secondary: #aaa590;
+  --color-border: #3a362e;
+  --color-border-light: #322f27;
+
+  --color-code-background: rgba(224, 220, 204, 0.1);
+  --color-code-text: #e0dccc;
+  --color-pre-background: #2d2a23;
+  --color-pre-text: #e0dccc;
+
+  --color-syntax-comment: #aaa590;
+  --color-syntax-keyword: #ff7b72;
+  --color-syntax-string: #a5d6ff;
+  --color-syntax-number: #79c0ff;
+  --color-syntax-function: #d2a8ff;
+  --color-syntax-variable: #ffa657;
+  --color-syntax-type: #79c0ff;
+
+  --color-search-highlight: #ffd54f;
+  --color-search-highlight-text: #000000;
+  --color-search-current-highlight: #ff9800;
+  --color-search-current-highlight-text: #000000;
+
+  --color-status-background: #2d2a23;
+  --color-status-text: #aaa590;
+}
+
+/* Silk theme (Kinu - Light cool monotone) */
+[data-theme="silk"] {
+  --color-primary: #6b6b72;
+  --color-primary-hover: #545459;
+  --color-background: #f3f3f8;
+  --color-surface: #ededf2;
+  --color-text: #2a2a2f;
+  --color-text-secondary: #6c6c71;
+  --color-border: #d8d8dd;
+  --color-border-light: #e3e3e8;
+
+  --color-code-background: rgba(42, 42, 47, 0.08);
+  --color-code-text: #2a2a2f;
+  --color-pre-background: #ededf2;
+  --color-pre-text: #2a2a2f;
+
+  --color-syntax-comment: #6c6c71;
+  --color-syntax-keyword: #d73a49;
+  --color-syntax-string: #032f62;
+  --color-syntax-number: #005cc5;
+  --color-syntax-function: #6f42c1;
+  --color-syntax-variable: #e36209;
+  --color-syntax-type: #005cc5;
+
+  --color-search-highlight: #ffeb3b;
+  --color-search-highlight-text: #000000;
+  --color-search-current-highlight: #ff9800;
+  --color-search-current-highlight-text: #000000;
+
+  --color-status-background: #ededf2;
+  --color-status-text: #6c6c71;
+}
+
+/* Ink theme (Sumi - Dark cool monotone) */
+[data-theme="ink"] {
+  --color-primary: #a3a3ae;
+  --color-primary-hover: #8a8a98;
+  --color-background: #1f1f26;
+  --color-surface: #292930;
+  --color-text: #dcdce3;
+  --color-text-secondary: #a0a0a7;
+  --color-border: #35353c;
+  --color-border-light: #2d2d33;
+
+  --color-code-background: rgba(220, 220, 227, 0.1);
+  --color-code-text: #dcdce3;
+  --color-pre-background: #292930;
+  --color-pre-text: #dcdce3;
+
+  --color-syntax-comment: #a0a0a7;
+  --color-syntax-keyword: #ff7b72;
+  --color-syntax-string: #a5d6ff;
+  --color-syntax-number: #79c0ff;
+  --color-syntax-function: #d2a8ff;
+  --color-syntax-variable: #ffa657;
+  --color-syntax-type: #79c0ff;
+
+  --color-search-highlight: #ffd54f;
+  --color-search-highlight-text: #000000;
+  --color-search-current-highlight: #ff9800;
+  --color-search-current-highlight-text: #000000;
+
+  --color-status-background: #292930;
+  --color-status-text: #a0a0a7;
+}
+
 /* AS/400 theme (IBM Green Screen) */
 [data-theme="as400"] {
   --color-background: #000000;

--- a/src/themes/__tests__/themes.test.ts
+++ b/src/themes/__tests__/themes.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe('getThemeByName', () => {
   it('returns correct theme for each known name', () => {
-    const knownNames: ThemeName[] = ['default', 'dark', 'pastel', 'vivid', 'darcula'];
+    const knownNames: ThemeName[] = ['default', 'dark', 'pastel', 'vivid', 'dawn', 'twilight', 'silk', 'ink', 'darcula'];
     for (const name of knownNames) {
       const theme = getThemeByName(name);
       expect(theme).toBeDefined();
@@ -65,8 +65,8 @@ describe('applyThemeToDocument', () => {
 });
 
 describe('themes array', () => {
-  it('contains exactly 6 themes', () => {
-    expect(themes).toHaveLength(6);
+  it('contains exactly 10 themes', () => {
+    expect(themes).toHaveLength(10);
   });
 
   it('each entry has name, displayName, and theme', () => {
@@ -92,31 +92,35 @@ describe('themes array', () => {
     }
   });
 
-  // T-TH-03: all 6 theme names are present
+  // T-TH-03: all 10 theme names are present in expected order
   it('T-TH-03: contains all expected theme names', () => {
     const names = themes.map(t => t.name);
-    expect(names).toEqual(['default', 'dark', 'pastel', 'vivid', 'darcula', 'as400']);
+    expect(names).toEqual([
+      'default', 'dark', 'pastel', 'vivid',
+      'dawn', 'twilight', 'silk', 'ink',
+      'darcula', 'as400',
+    ]);
   });
 });
 
 describe('getVisibleThemes', () => {
-  // T-TH-04: without unlock returns 5 themes (excludes hidden)
+  // T-TH-04: without unlock returns 9 themes (excludes hidden)
   it('T-TH-04: returns only non-hidden themes by default', () => {
     const visible = getVisibleThemes();
-    expect(visible).toHaveLength(5);
+    expect(visible).toHaveLength(9);
     expect(visible.find(t => t.name === 'as400')).toBeUndefined();
   });
 
-  // T-TH-05: with as400 unlocked returns all 6 themes
+  // T-TH-05: with as400 unlocked returns all 10 themes
   it('T-TH-05: includes unlocked secret themes', () => {
     const visible = getVisibleThemes(['as400']);
-    expect(visible).toHaveLength(6);
+    expect(visible).toHaveLength(10);
     expect(visible.find(t => t.name === 'as400')).toBeDefined();
   });
 
   // T-TH-06: empty unlock array still excludes hidden
   it('T-TH-06: empty unlock array excludes hidden themes', () => {
     const visible = getVisibleThemes([]);
-    expect(visible).toHaveLength(5);
+    expect(visible).toHaveLength(9);
   });
 });

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,6 +1,6 @@
 import { createTheme, Theme } from '@mui/material/styles';
 
-export type ThemeName = 'default' | 'dark' | 'pastel' | 'vivid' | 'darcula' | 'as400';
+export type ThemeName = 'default' | 'dark' | 'pastel' | 'vivid' | 'dawn' | 'twilight' | 'silk' | 'ink' | 'darcula' | 'as400';
 
 export interface ThemeConfig {
   name: ThemeName;
@@ -161,6 +161,142 @@ const vividTheme = createTheme({
   // Improve code syntax highlight visibility with custom CSS variables
   shape: {
     borderRadius: 12,
+  },
+});
+
+// Dawn Theme (Akatsuki - Light with subtle warm/terracotta tint)
+const dawnTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#785e4f',
+    },
+    secondary: {
+      main: '#977e71',
+    },
+    background: {
+      default: '#faf6f4',
+      paper: '#f4edea',
+    },
+    text: {
+      primary: '#39312d',
+      secondary: '#796b64',
+    },
+    divider: '#e6dad2',
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+  },
+});
+
+// Twilight Theme (Tasogare - Dark with subtle warm yellow tint)
+const twilightTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#c8be9c',
+    },
+    secondary: {
+      main: '#9a9078',
+    },
+    background: {
+      default: '#25231d',
+      paper: '#2d2a23',
+    },
+    text: {
+      primary: '#e0dccc',
+      secondary: '#aaa590',
+    },
+    divider: '#3a362e',
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+  },
+});
+
+// Silk Theme (Kinu - Light monotone with faint blue tint)
+const silkTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#6b6b72',
+    },
+    secondary: {
+      main: '#7c7c81',
+    },
+    background: {
+      default: '#f3f3f8',
+      paper: '#ededf2',
+    },
+    text: {
+      primary: '#2a2a2f',
+      secondary: '#6c6c71',
+    },
+    divider: '#d8d8dd',
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
+  },
+});
+
+// Ink Theme (Sumi - Dark monotone with faint blue tint)
+const inkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#a3a3ae',
+    },
+    secondary: {
+      main: '#86868d',
+    },
+    background: {
+      default: '#1f1f26',
+      paper: '#292930',
+    },
+    text: {
+      primary: '#dcdce3',
+      secondary: '#a0a0a7',
+    },
+    divider: '#35353c',
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          '&::before': {
+            display: 'none',
+          },
+        },
+      },
+    },
   },
 });
 
@@ -380,6 +516,26 @@ export const themes: ThemeConfig[] = [
     theme: vividTheme,
   },
   {
+    name: 'dawn',
+    displayName: 'Dawn',
+    theme: dawnTheme,
+  },
+  {
+    name: 'twilight',
+    displayName: 'Twilight',
+    theme: twilightTheme,
+  },
+  {
+    name: 'silk',
+    displayName: 'Silk',
+    theme: silkTheme,
+  },
+  {
+    name: 'ink',
+    displayName: 'Ink',
+    theme: inkTheme,
+  },
+  {
     name: 'darcula',
     displayName: 'Darcula',
     theme: darculaTheme,
@@ -404,6 +560,11 @@ export const getThemeByName = (name: ThemeName): Theme => {
 export const getThemeDisplayName = (name: ThemeName): string => {
   const themeConfig = themes.find(t => t.name === name);
   return themeConfig ? themeConfig.displayName : 'Default';
+};
+
+export const isDarkTheme = (name: ThemeName): boolean => {
+  const themeConfig = themes.find(t => t.name === name);
+  return themeConfig ? themeConfig.theme.palette.mode === 'dark' : false;
 };
 
 // Set the data-theme attribute on the HTML element

--- a/src/utils/__tests__/exportStyles.test.ts
+++ b/src/utils/__tests__/exportStyles.test.ts
@@ -8,24 +8,36 @@ import {
 } from '../exportStyles';
 
 describe('getExportThemeColors', () => {
-  it('returns light theme colors by default', () => {
-    const colors = getExportThemeColors(false);
+  it('returns default theme palette when no theme specified', () => {
+    const colors = getExportThemeColors();
     expect(colors.backgroundColor).toBe('#ffffff');
-    expect(colors.textColor).toBe('#333333');
-    expect(colors.linkColor).toBe('#0366d6');
+    expect(colors.textColor).toBe('#000000');
+    expect(colors.linkColor).toBe('#1976d2');
   });
 
-  it('returns dark theme colors when darkMode=true', () => {
-    const colors = getExportThemeColors(true);
-    expect(colors.backgroundColor).toBe('#1a1a1a');
-    expect(colors.textColor).toBe('#e0e0e0');
-    expect(colors.linkColor).toBe('#58a6ff');
+  it('returns dark theme palette for theme="dark"', () => {
+    const colors = getExportThemeColors('dark');
+    expect(colors.backgroundColor).toBe('#121212');
+    expect(colors.textColor).toBe('#ffffff');
+    expect(colors.linkColor).toBe('#90caf9');
   });
 
-  it('returns darcula theme colors', () => {
-    const colors = getExportThemeColors(false, 'darcula');
+  it('returns darcula theme palette', () => {
+    const colors = getExportThemeColors('darcula');
     expect(colors.backgroundColor).toBe('#2B2B2B');
-    expect(colors.textColor).toBe('#A9B7C6');
+    expect(colors.linkColor).toBe('#CC7832');
+  });
+
+  it('returns dawn theme palette (new theme)', () => {
+    const colors = getExportThemeColors('dawn');
+    expect(colors.backgroundColor).toBe('#faf6f4');
+    expect(colors.linkColor).toBe('#785e4f');
+  });
+
+  it('returns ink theme palette (new theme)', () => {
+    const colors = getExportThemeColors('ink');
+    expect(colors.backgroundColor).toBe('#1f1f26');
+    expect(colors.linkColor).toBe('#a3a3ae');
   });
 });
 
@@ -46,7 +58,7 @@ describe('getHighlightStyleDataUri', () => {
 
 describe('generateExportCSS', () => {
   it('includes theme colors in CSS output', () => {
-    const colors = getExportThemeColors(false);
+    const colors = getExportThemeColors();
     const css = generateExportCSS(colors);
     expect(css).toContain(colors.backgroundColor);
     expect(css).toContain(colors.textColor);
@@ -56,7 +68,7 @@ describe('generateExportCSS', () => {
   });
 
   it('constrains images to fit within parent element', () => {
-    const colors = getExportThemeColors(false);
+    const colors = getExportThemeColors();
     const css = generateExportCSS(colors);
     expect(css).toContain('img');
     expect(css).toContain('max-width: 100%');
@@ -64,7 +76,7 @@ describe('generateExportCSS', () => {
   });
 
   it('uses auto-wrap as the default table layout', () => {
-    const colors = getExportThemeColors(false);
+    const colors = getExportThemeColors();
     const css = generateExportCSS(colors);
     expect(css).toContain('table-layout: auto');
     expect(css).not.toContain('table-layout: fixed');
@@ -152,16 +164,22 @@ describe('buildExportHTML', () => {
     expect(html).toContain('highlightAll');
   });
 
-  it('uses dark theme colors when darkMode=true', () => {
-    const html = buildExportHTML('<p>Dark</p>', true);
-    expect(html).toContain('#1a1a1a');
-    expect(html).toContain('#e0e0e0');
+  it('uses dark theme palette colors', () => {
+    const html = buildExportHTML('<p>Dark</p>', true, 'dark');
+    expect(html).toContain('#121212');
+    expect(html).toContain('#ffffff');
   });
 
-  it('uses darcula theme colors', () => {
-    const html = buildExportHTML('<p>Darcula</p>', false, 'darcula');
+  it('uses darcula theme palette colors', () => {
+    const html = buildExportHTML('<p>Darcula</p>', true, 'darcula');
     expect(html).toContain('#2B2B2B');
-    expect(html).toContain('#A9B7C6');
+    expect(html).toContain('#CC7832');
+  });
+
+  it('uses ink theme palette colors (new theme)', () => {
+    const html = buildExportHTML('<p>Ink</p>', true, 'ink');
+    expect(html).toContain('#1f1f26');
+    expect(html).toContain('#a3a3ae');
   });
 
   it('honors an explicit tableLayout argument', () => {

--- a/src/utils/exportStyles.ts
+++ b/src/utils/exportStyles.ts
@@ -1,4 +1,6 @@
+import { alpha } from '@mui/material/styles';
 import { TableLayoutMode, DEFAULT_PREVIEW_SETTINGS } from '../types/settings';
+import { getThemeByName, ThemeName } from '../themes';
 
 /** Theme color palette for HTML export */
 export interface ExportThemeColors {
@@ -13,17 +15,24 @@ export interface ExportThemeColors {
 
 /**
  * Compute theme-aware colors for HTML export.
+ * Reads the actual MUI palette of the selected theme so all themes (including
+ * the new Dawn / Twilight / Silk / Ink) export with their proper colors.
  */
-export function getExportThemeColors(darkMode: boolean, theme?: string): ExportThemeColors {
-  const isDark = darkMode || theme === 'darcula';
+export function getExportThemeColors(theme?: string): ExportThemeColors {
+  const themeName = (theme || 'default') as ThemeName;
+  const muiTheme = getThemeByName(themeName);
+  const { palette } = muiTheme;
+  // Code block bg derived from text color so it stays visible even when a
+  // theme leaves background.paper === background.default (Default / Vivid).
+  const codeBackground = alpha(palette.text.primary, palette.mode === 'dark' ? 0.10 : 0.06);
   return {
-    backgroundColor: theme === 'darcula' ? '#2B2B2B' : (isDark ? '#1a1a1a' : '#ffffff'),
-    textColor: theme === 'darcula' ? '#A9B7C6' : (isDark ? '#e0e0e0' : '#333333'),
-    codeBackground: theme === 'darcula' ? '#2d2d2d' : (isDark ? '#2d2d2d' : '#f6f8fa'),
-    borderColor: theme === 'darcula' ? '#404040' : (isDark ? '#404040' : '#eaecef'),
-    linkColor: theme === 'darcula' ? '#58a6ff' : (isDark ? '#58a6ff' : '#0366d6'),
-    blockquoteColor: theme === 'darcula' ? '#a0a0a0' : (isDark ? '#a0a0a0' : '#6a737d'),
-    inlineCodeBackground: theme === 'darcula' ? 'rgba(255,255,255,0.1)' : (isDark ? 'rgba(255,255,255,0.1)' : 'rgba(27,31,35,0.05)'),
+    backgroundColor: palette.background.default,
+    textColor: palette.text.primary,
+    codeBackground,
+    borderColor: palette.divider,
+    linkColor: palette.primary.main,
+    blockquoteColor: palette.text.secondary,
+    inlineCodeBackground: alpha(palette.text.primary, 0.08),
   };
 }
 
@@ -34,9 +43,8 @@ const HLJS_LIGHT_CSS = `.hljs{display:block;overflow-x:auto;padding:0.5em;color:
 /**
  * Get a data URI for highlight.js CSS based on theme.
  */
-export function getHighlightStyleDataUri(darkMode: boolean, theme?: string): string {
-  const isDark = darkMode || theme === 'darcula';
-  const css = isDark ? HLJS_DARK_CSS : HLJS_LIGHT_CSS;
+export function getHighlightStyleDataUri(darkMode: boolean): string {
+  const css = darkMode ? HLJS_DARK_CSS : HLJS_LIGHT_CSS;
   return 'data:text/css;base64,' + btoa(css);
 }
 
@@ -256,9 +264,9 @@ export function buildExportHTML(
   theme?: string,
   tableLayout: TableLayoutMode = DEFAULT_PREVIEW_SETTINGS.tableLayout,
 ): string {
-  const colors = getExportThemeColors(darkMode, theme);
+  const colors = getExportThemeColors(theme);
   const css = generateExportCSS(colors, tableLayout);
-  const highlightStyle = getHighlightStyleDataUri(darkMode, theme);
+  const highlightStyle = getHighlightStyleDataUri(darkMode);
 
   return `
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary

Adds four new themes designed around Japanese concepts (Dawn / Twilight / Silk / Ink). Display names are English in every locale except Japanese, where they appear as 暁 / 黄昏 /
絹 / 墨. The change also refactors how the app derives dark/light styling so each theme's palette flows through editor / preview / status bar / export consistently.

## Changes

- Added four new themes in `src/themes/index.ts`: Dawn (warm light), Twilight (warm dark), Silk (cool light monotone), Ink (cool dark monotone). Theme order is now Default → Dark
→ Pastel → Vivid → Dawn → Twilight → Silk → Ink → Darcula.
- Localized theme display names through `settings.appearance.themes.<name>` keys across all 14 locale files. Existing themes (Default / Dark / Pastel / Vivid / Darcula) are now
English in every language for consistency; only the four new themes switch to kanji in `ja.json`. UI references in `Settings.tsx` and `StatusBar.tsx` were updated to use the
translation key with `displayName` as a fallback.
- Added a centralized `isDarkTheme(name)` helper in `themes/index.ts` (reads `palette.mode === 'dark'`) and replaced hardcoded `theme === 'dark' || theme === 'as400'` checks in
`App.tsx` and `AppContent.tsx`. The Monaco editor theme in `Editor.tsx` now follows `darkMode` directly, dropping the Darcula special case.
- Refactored `StatusBar.tsx`, `Preview.tsx`, `MarpPreview.tsx`, and `exportStyles.ts` to read colors from the MUI palette via `useTheme()` / `getThemeByName()` instead of
hardcoded values. AS/400-only effects (scanline, text-shadow, monospace font family) are preserved as the remaining theme-name branches.
- Added the missing `[data-theme="dawn|twilight|silk|ink"]` blocks in `src/styles/variables.css` so the markdown preview's CSS-variable-driven styling (`--color-text`,
`--color-pre-background`, syntax colors, etc.) renders correctly under the new themes. Extended `markdown.css` dark-theme selectors to include `twilight` and `ink`. The `pre`
background and table header now use `var(--color-pre-background)` so they always match the `.hljs` background.
- Documented the dual theming system (MUI palette + CSS variables) and a checklist for adding future themes in `CLAUDE.md` to prevent the same gap from recurring.

## Tests

- `src/themes/__tests__/themes.test.ts`: updated counts (5 → 9 visible themes) and the expected name array, and added the new themes to the known-name iteration.
- `src/utils/__tests__/exportStyles.test.ts`: rewrote color assertions against the new palette-driven values and added new cases for Dawn and Ink (`backgroundColor`, `linkColor`).
- `src/components/__tests__/Editor.test.tsx` (T-ED-04) and `src/components/__tests__/Preview.test.tsx` (T-PV-12): updated to pass `darkMode={true}` explicitly with Darcula since
the components no longer special-case theme names. `StatusBar.test.tsx`'s `useTranslation` mock was extended to honor a `defaultValue` argument so the new fallback pattern works