### PR TITLE
Fix false Marp detection when "marp: true" appears inside a code block

### DIFF
--- a/src/utils/__tests__/marpRenderer.test.ts
+++ b/src/utils/__tests__/marpRenderer.test.ts
@@ -100,6 +100,64 @@ marp:true
     // The regex MARP_FRONTMATTER_RE uses \s* so space is optional
     expect(contentIsMarp(content)).toBe(true);
   });
+
+  // T-MR-04: regression — a markdown article that demonstrates Marp syntax
+  // inside a fenced code block must NOT be detected as Marp. Front-matter
+  // only counts when it sits at the very start of the document.
+  it('T-MR-04: returns false for marp: true inside a fenced code block', () => {
+    const content = `# Article
+
+Some intro text. The following is an *example* of Marp syntax:
+
+\`\`\`markdown
+---
+marp: true
+theme: default
+---
+
+# Title slide
+\`\`\`
+
+End of article.`;
+    expect(contentIsMarp(content)).toBe(false);
+  });
+
+  // T-MR-05: a document whose body contains thematic breaks (\`---\`) and the
+  // literal text \`marp: true\` must not be detected just because both tokens
+  // happen to appear on their own lines.
+  it('T-MR-05: returns false when --- and marp: true appear only in the body', () => {
+    const content = `# Article
+
+Intro.
+
+---
+
+marp: true is how you enable Marp.
+
+---
+
+End.`;
+    expect(contentIsMarp(content)).toBe(false);
+  });
+
+  // T-MR-06: a real front-matter without marp: true must still return false
+  // even if a fenced code block later in the document contains a marp: true
+  // example.
+  it('T-MR-06: ignores marp: true in code block when front-matter lacks it', () => {
+    const content = `---
+title: Marp Tutorial
+author: Someone
+---
+
+# How to write Marp
+
+\`\`\`markdown
+---
+marp: true
+---
+\`\`\``;
+    expect(contentIsMarp(content)).toBe(false);
+  });
 });
 
 describe('renderMarp', () => {

--- a/src/utils/marpRenderer.ts
+++ b/src/utils/marpRenderer.ts
@@ -11,15 +11,20 @@ async function getMarp(): Promise<Marp> {
   return new MarpClass();
 }
 
-/** YAML front-matter detection for marp: true */
-const MARP_FRONTMATTER_RE = /^---\s*\n[\s\S]*?^marp:\s*true\b[\s\S]*?^---\s*$/m;
+// YAML front-matter is delimited by `---` lines and must sit at the very start
+// of the document. Anchoring the opening fence to position 0 prevents matches
+// against `---` that appear inside fenced code blocks (e.g. a Marp tutorial
+// that shows front-matter as an example).
+const MARP_FRONTMATTER_RE = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
 
 /**
  * Check whether the markdown content has a `marp: true` YAML front-matter.
  * Synchronous — no library load needed.
  */
 export function contentIsMarp(content: string): boolean {
-  return MARP_FRONTMATTER_RE.test(content);
+  const match = MARP_FRONTMATTER_RE.exec(content);
+  if (!match) return false;
+  return /^marp:\s*true\b/m.test(match[1]);
 }
 
 export interface MarpRenderResult {


### PR DESCRIPTION
## Summary

Tightens YAML front-matter detection so a document that merely shows `marp: true` in a fenced code block (e.g. a
Marp tutorial) is no longer mistakenly rendered as a Marp slide deck. Front-matter must now sit at the very start of
the document, and `marp: true` is only checked inside the front-matter block — not anywhere in the file.

## Changes

- Replaced the multiline regex `/^---\s*\n[\s\S]*?^marp:\s*true\b[\s\S]*?^---\s*$/m` in `src/utils/marpRenderer.ts`
with a two-step check: a non-multiline front-matter regex anchored to position 0 (`/^---[
\t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/`) followed by a `marp:\s*true` test against the captured front-matter
body. This avoids matching `---` fences and `marp: true` lines that appear only in the document body or inside
fenced code blocks.
- Added an inline comment documenting why anchoring matters (Marp tutorials that demonstrate front-matter syntax
inside code fences previously triggered false positives).

## Tests

Three regression cases added in `src/utils/__tests__/marpRenderer.test.ts`:

- **T-MR-04**: a body that contains a fenced ```` ```markdown ```` block showing example `---` / `marp: true` /
`---` front-matter must return `false`.
- **T-MR-05**: a document whose body has thematic breaks (`---`) and the literal text `marp: true` (not inside
front-matter) must return `false`.
- **T-MR-06**: a real front-matter at the document start that does *not* contain `marp: true` returns `false`, even
when a later code block contains a `marp: true` example.