### PR TITLE
Fix KaTeX crash and table/preview corruption from math rendering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,10 @@ updates:
       # メジャーバージョンアップは手動で確認
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # KaTeX 0.17.0 で \tilde 等のアクセント×\mathbf が htmlBuilder TypeError でクラッシュ（#354）。
+      # 修正版が出るまで 0.16 系に固定（0.x のため 0.16→0.17 は dependabot 上 minor 扱い）。
+      - dependency-name: "katex"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
 
   # Cargo dependencies
   - package-ecosystem: "cargo"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@tauri-apps/plugin-window-state": "^2.4.0",
         "highlight.js": "^11.11.1",
         "i18next": "^25.10.10",
-        "katex": "^0.17.0",
+        "katex": "^0.16.22",
         "marked": "^16.4.2",
         "mermaid": "^11.15.0",
         "react": "19.2.6",
@@ -1593,22 +1593,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@marp-team/marp-core/node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
       }
     },
     "node_modules/@marp-team/marpit": {
@@ -5590,9 +5574,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
-      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -5861,22 +5845,6 @@
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
-      }
-    },
-    "node_modules/mermaid/node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
       }
     },
     "node_modules/mermaid/node_modules/stylis": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@tauri-apps/plugin-window-state": "^2.4.0",
     "highlight.js": "^11.11.1",
     "i18next": "^25.10.10",
-    "katex": "^0.17.0",
+    "katex": "^0.16.22",
     "marked": "^16.4.2",
     "mermaid": "^11.15.0",
     "react": "19.2.6",

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -45,6 +45,10 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
   const [htmlContent, setHtmlContent] = useState<string>('');
   const [exportError, setExportError] = useState<string | null>(null);
   const blobUrlsRef = useRef<string[]>([]);
+  // Latest KaTeX placeholder->HTML restore fn for the current processedContent.
+  // KaTeX renders to placeholders BEFORE marked and is restored AFTER, so both
+  // the preview and the HTML export must run this on marked's output (#354).
+  const katexRestoreRef = useRef<(html: string) => string>((html) => html);
 
   // Revoke all blob URLs on unmount to prevent memory leaks
   useEffect(() => {
@@ -96,15 +100,22 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
         if (stale) return;
         let processedMarkdown = processEasterEggBlocks(result.processedContent);
 
-        // Process KaTeX math expressions before marked parsing (lazy-loaded)
+        // Process KaTeX math expressions before marked parsing (lazy-loaded).
+        // Math is replaced with inert placeholders here and the rendered KaTeX
+        // HTML is swapped back in AFTER marked, so marked never sees KaTeX output
+        // (which can collide with markdown syntax — e.g. accent tildes; #354).
+        let restoreKatex: (html: string) => string = (html) => html;
         if (renderingSettings.enableKatex && contentHasKatex(processedMarkdown)) {
           try {
-            processedMarkdown = await processKatex(processedMarkdown);
+            const processed = await processKatex(processedMarkdown);
+            processedMarkdown = processed.markdown;
+            restoreKatex = processed.restore;
           } catch (err) {
             console.warn('KaTeX processing failed, showing raw math syntax:', err);
           }
           if (stale) return;
         }
+        katexRestoreRef.current = restoreKatex;
 
         // Convert Markdown to HTML
         const markedResult = marked(processedMarkdown, {
@@ -120,6 +131,9 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
         } else {
           processedHtml = await markedResult;
         }
+
+        // Swap rendered KaTeX HTML back in for its placeholders.
+        processedHtml = restoreKatex(processedHtml);
 
         // Process Mermaid diagrams (lazy-loaded, after marked parsing)
         if (renderingSettings.enableMermaid && contentHasMermaid(processedMarkdown)) {
@@ -343,6 +357,10 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
       } else {
         exportHtml = await markedExportResult;
       }
+
+      // processedContent holds KaTeX placeholders; restore the rendered HTML
+      // after marked (same as the preview path).
+      exportHtml = katexRestoreRef.current(exportHtml);
 
       // Process Mermaid diagrams for export (renders as inline SVG)
       if (renderingSettings.enableMermaid && contentHasMermaid(processedContent)) {

--- a/src/components/__tests__/Preview.test.tsx
+++ b/src/components/__tests__/Preview.test.tsx
@@ -78,7 +78,19 @@ vi.mock('marked', () => {
 // Mock markdownRenderers for verifying render pipeline calls
 vi.mock('../../utils/markdownRenderers', () => ({
   renderCode: vi.fn(),
-  processKatex: vi.fn().mockImplementation(async (md: string) => md.replace(/\$([^$]+)\$/g, '<span class="katex">$1</span>')),
+  // Mirrors the real placeholder/restore contract: math -> placeholder before
+  // marked, rendered HTML swapped back via restore() after marked.
+  processKatex: vi.fn().mockImplementation(async (md: string) => {
+    const rendered: string[] = [];
+    const markdown = md.replace(/\$([^$]+)\$/g, (_m, tex) => {
+      const placeholder = `KaTeXmathPLACEHOLDER${rendered.length}END`;
+      rendered.push(`<span class="katex">${tex}</span>`);
+      return placeholder;
+    });
+    const restore = (html: string) =>
+      html.replace(/KaTeXmathPLACEHOLDER(\d+)END/g, (_m, i) => rendered[Number(i)] ?? '');
+    return { markdown, restore };
+  }),
   contentHasKatex: vi.fn().mockImplementation((content: string) => /\$/.test(content)),
   processMermaidBlocks: vi.fn().mockImplementation(async (html: string) => html.replace(/mermaid-placeholder/g, '<div class="mermaid-rendered">diagram</div>')),
   contentHasMermaid: vi.fn().mockImplementation((content: string) => /mermaid/.test(content)),

--- a/src/utils/__tests__/katexRegression.test.ts
+++ b/src/utils/__tests__/katexRegression.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest';
+// IMPORTANT: This file intentionally does NOT mock 'katex'. It exercises the
+// REAL KaTeX library so it can catch version regressions. (markdownRenderers.test.ts
+// mocks katex and therefore cannot detect bugs inside KaTeX itself.)
+import katex from 'katex';
+import { marked } from 'marked';
+import { processKatex } from '../markdownRenderers';
+
+// processKatex lazy-imports the KaTeX stylesheet; stub it so the real pipeline
+// (real KaTeX + real marked) can run under vitest without a CSS loader.
+vi.mock('katex/dist/katex.min.css', () => ({}));
+
+/**
+ * Regression test for issue #354.
+ * https://github.com/Bokuchi-Editor/bokuchi/issues/354
+ *
+ * KaTeX 0.17.0 introduced a regression: an accent command (\tilde, \hat, \bar,
+ * \vec, ...) whose argument contains a command that has its own htmlBuilder
+ * (e.g. \mathbf, \mathrm, \mathbb) crashes during rendering with:
+ *   TypeError: Cannot read properties of undefined (reading 'htmlBuilder')
+ *
+ * Crucially this is a TypeError, NOT a KaTeX ParseError, so `throwOnError: false`
+ * does NOT suppress it — the exception escapes renderToString and breaks the
+ * whole preview render. KaTeX 0.16.x renders the same input correctly.
+ *
+ * These tests FAIL on katex 0.17.0 and PASS on katex 0.16.x. They are the guard
+ * that lets us safely bump katex again once KaTeX ships a fix (see CLAUDE.md
+ * "Temporary Overrides" and .github/dependabot.yml).
+ */
+describe('KaTeX accent regression (issue #354)', () => {
+  const accentWithCommand = [
+    '\\tilde{\\mathbf{x}}',
+    '\\hat{\\mathbf{x}}',
+    '\\bar{\\mathbf{x}}',
+    '\\vec{\\mathbf{x}}',
+  ];
+
+  it.each(accentWithCommand)(
+    'renders %s without throwing (even with throwOnError:false)',
+    (tex) => {
+      expect(() =>
+        katex.renderToString(tex, { displayMode: false, throwOnError: false }),
+      ).not.toThrow();
+
+      const html = katex.renderToString(tex, { displayMode: false, throwOnError: false });
+      expect(html).toContain('class="katex"');
+    },
+  );
+
+  it('renders the exact expression from the bug report without throwing', () => {
+    const tex =
+      '\\tilde{\\mathbf{x}} = \\mathbf{x} - \\bar{x}\\mathbf{1}';
+    expect(() =>
+      katex.renderToString(tex, { displayMode: false, throwOnError: false }),
+    ).not.toThrow();
+    expect(
+      katex.renderToString(tex, { displayMode: false, throwOnError: false }),
+    ).toContain('class="katex"');
+  });
+
+  it('still renders simple accents and plain math (sanity)', () => {
+    for (const tex of ['\\tilde{x}', '\\mathbf{x}', '\\frac{a}{b}', 'x^2']) {
+      expect(() =>
+        katex.renderToString(tex, { displayMode: false, throwOnError: false }),
+      ).not.toThrow();
+    }
+  });
+});
+
+/**
+ * Second regression for issue #354: blank preview when two accent expressions
+ * appear in the same document.
+ *
+ * KaTeX renders an accent as a literal tilde character (\tilde ->
+ * `<span class="mord">~</span>`, present in both HTML and MathML output). If that
+ * rendered HTML reaches marked's input, GFM strikethrough (`~...~`) pairs the
+ * tildes from two separate expressions and injects unbalanced <del> tags INTO
+ * the rendered KaTeX markup, corrupting the DOM so the whole preview renders
+ * blank.
+ *
+ * The fix: processKatex replaces each expression with an inert placeholder and
+ * returns restore() to swap the rendered HTML back in AFTER marked, so marked
+ * never sees KaTeX output. This test runs the REAL pipeline (real processKatex +
+ * real marked + restore, exactly as Preview.tsx does) end to end.
+ */
+describe('KaTeX + marked pipeline regression (issue #354 blank preview)', () => {
+  const runPipeline = async (markdown: string) => {
+    const { markdown: placeholderMd, restore } = await processKatex(markdown);
+    const rendered = await marked(placeholderMd, { breaks: true, gfm: true });
+    return { placeholderMd, html: restore(rendered) };
+  };
+
+  it('does not let GFM strikethrough corrupt two accent expressions', async () => {
+    // Exact shape from the bug report: two inline accent expressions on one line.
+    const { placeholderMd, html } = await runPipeline(
+      String.raw`$\tilde{\mathbf{x}}$, $\tilde{\mathbf{y}}$`,
+    );
+
+    // marked must only ever see inert placeholders, never KaTeX output.
+    expect(placeholderMd).not.toContain('<span');
+    expect(placeholderMd).not.toContain('~');
+    // So GFM strikethrough produced no <del> tags inside the math markup.
+    expect(html).not.toContain('<del>');
+    // And both expressions actually rendered.
+    expect(html).toContain('<span class="katex"');
+    // Sanity: <span> tags stay balanced (corruption would unbalance them).
+    const open = (html.match(/<span/g) || []).length;
+    const close = (html.match(/<\/span>/g) || []).length;
+    expect(open).toBe(close);
+  });
+
+  it('renders the full bug-report expression through the pipeline', async () => {
+    const { html } = await runPipeline(
+      String.raw`$\tilde{\mathbf{x}} = \mathbf{x} - \bar{x}\mathbf{1}$, $\tilde{\mathbf{y}} = \mathbf{y} - \bar{y}\mathbf{1}$`,
+    );
+
+    expect(html).not.toContain('<del>');
+    expect(html).not.toContain('katex-error');
+    expect(html).toContain('<span class="katex"');
+  });
+});
+
+/**
+ * Regression for issue #358: a `$|x - y|$` absolute value inside a Markdown table.
+ *
+ * Same root cause / same fix as #354: the math placeholder contains no `|`, so
+ * marked's (block-level) table parser counts the correct number of cells instead
+ * of splitting the row on the bars inside the formula. The user can therefore
+ * write a plain single-bar absolute value (not the LaTeX norm `\|`) and keep both
+ * the table layout AND the correct notation. Guards the placeholder pipeline so a
+ * future refactor that inlines KaTeX HTML before marked can't silently break it.
+ */
+describe('KaTeX + marked pipeline regression (issue #358 |…| in tables)', () => {
+  const runPipeline = async (markdown: string) => {
+    const { markdown: placeholderMd, restore } = await processKatex(markdown);
+    const rendered = await marked(placeholderMd, { breaks: true, gfm: true });
+    return { placeholderMd, html: restore(rendered) };
+  };
+
+  it('keeps the table intact for an unescaped absolute value in a cell', async () => {
+    const md = [
+      '| Formula | Description |',
+      '| --- | --- |',
+      '| $d(x, y) = |x - y|$ | Distance of |',
+      '',
+    ].join('\n');
+
+    const { placeholderMd, html } = await runPipeline(md);
+
+    // The bars are hidden inside the placeholder, so marked sees no extra `|`.
+    expect(placeholderMd).not.toContain('|x - y|');
+    // The two-column table survives (would be >2 cells if the row split on `|`).
+    expect(html).toContain('<table>');
+    expect((html.match(/<th[ >]/g) || []).length).toBe(2);
+    expect((html.match(/<td[ >]/g) || []).length).toBe(2);
+    // Formula renders, and its inner content does not leak into a bare cell.
+    expect(html).toContain('<span class="katex"');
+    expect(html).not.toMatch(/<td[^>]*>\s*x - y\s*<\/td>/);
+  });
+
+  it('renders a single-bar absolute value (not the norm \\|)', async () => {
+    const { html } = await runPipeline('| f | d |\n| --- | --- |\n| $|x - y|$ | abs |\n');
+
+    // KaTeX encodes the original TeX in the MathML annotation; a true absolute
+    // value keeps single bars there, whereas a norm would be `\|x - y\|`.
+    expect(html).toContain('application/x-tex">|x - y|</annotation>');
+    expect(html).not.toContain(String.raw`\|x - y\|`);
+  });
+});

--- a/src/utils/__tests__/markdownRenderers.test.ts
+++ b/src/utils/__tests__/markdownRenderers.test.ts
@@ -38,7 +38,6 @@ import {
   processKatex,
   processMermaidBlocks,
   reinitializeMermaid,
-  processRenderingExtensions,
 } from '../markdownRenderers';
 
 import mermaid from 'mermaid';
@@ -141,37 +140,55 @@ describe('contentHasKatex repeated calls', () => {
 });
 
 describe('processKatex', () => {
+  // processKatex replaces math with placeholders and returns a restore() that
+  // swaps the rendered HTML back in (intended to run on marked's output, #354).
+  // For these unit tests we restore against the placeholder markdown directly.
+  const render = async (input: string) => {
+    const { markdown, restore } = await processKatex(input);
+    return { markdown, html: restore(markdown) };
+  };
+
+  it('replaces math with an inert placeholder (no raw HTML before marked)', async () => {
+    const { markdown } = await render('The value $x^2$ is positive');
+    // marked must never see KaTeX output, only an alphanumeric placeholder.
+    expect(markdown).not.toContain('<span');
+    expect(markdown).not.toContain('$');
+    expect(markdown).toMatch(/KaTeXmathPLACEHOLDER\d+END/);
+  });
+
   it('renders display math', async () => {
-    const result = await processKatex('Before $$E = mc^2$$ After');
-    expect(result).toContain('katex-display');
-    expect(result).toContain('E = mc^2');
-    expect(result).toContain('Before');
-    expect(result).toContain('After');
+    const { html } = await render('Before $$E = mc^2$$ After');
+    expect(html).toContain('katex-display');
+    expect(html).toContain('E = mc^2');
+    expect(html).toContain('Before');
+    expect(html).toContain('After');
   });
 
   it('renders inline math', async () => {
-    const result = await processKatex('The value $x^2$ is positive');
-    expect(result).toContain('katex');
-    expect(result).toContain('x^2');
-    expect(result).not.toContain('katex-display');
+    const { html } = await render('The value $x^2$ is positive');
+    expect(html).toContain('katex');
+    expect(html).toContain('x^2');
+    expect(html).not.toContain('katex-display');
   });
 
   it('does not process math inside code blocks', async () => {
     const input = '```\n$x^2$\n```';
-    const result = await processKatex(input);
-    expect(result).toBe(input);
+    const { markdown, html } = await render(input);
+    expect(markdown).toBe(input);
+    expect(html).toBe(input);
   });
 
   it('does not process math inside inline code', async () => {
     const input = 'Use `$x$` for math';
-    const result = await processKatex(input);
-    expect(result).toBe(input);
+    const { markdown, html } = await render(input);
+    expect(markdown).toBe(input);
+    expect(html).toBe(input);
   });
 
   it('handles both display and inline in the same content', async () => {
-    const result = await processKatex('Inline $a$ and display $$b$$');
-    expect(result).toContain('<span class="katex">a</span>');
-    expect(result).toContain('<span class="katex katex-display">b</span>');
+    const { html } = await render('Inline $a$ and display $$b$$');
+    expect(html).toContain('<span class="katex">a</span>');
+    expect(html).toContain('<span class="katex katex-display">b</span>');
   });
 
   it('strips newlines from KaTeX output to prevent table parsing issues', async () => {
@@ -183,9 +200,9 @@ describe('processKatex', () => {
       '<span class="katex"><svg>\n<path d="c-2.7,0,-7.17,-2.7\n-13.5,-8"/>\n</svg></span>'
     );
 
-    const result = await processKatex('$\\sqrt{1}$');
-    expect(result).not.toContain('\n');
-    expect(result).toContain('<svg><path d="c-2.7,0,-7.17,-2.7-13.5,-8"/></svg>');
+    const { html } = await render('$\\sqrt{1}$');
+    expect(html).not.toContain('\n');
+    expect(html).toContain('<svg><path d="c-2.7,0,-7.17,-2.7-13.5,-8"/></svg>');
 
     // Restore default mock behavior
     mockRenderToString.mockImplementation((tex: string, opts?: { displayMode?: boolean }) => {
@@ -264,69 +281,3 @@ describe('reinitializeMermaid', () => {
   });
 });
 
-describe('processRenderingExtensions', () => {
-  beforeEach(() => {
-    mockRender.mockReset();
-  });
-
-  it('processes both KaTeX and Mermaid when enabled and content uses them', async () => {
-    mockRender.mockResolvedValue({ svg: '<svg>diagram</svg>', diagramType: 'flowchart' });
-    const markdown = 'Math: $x^2$ and ```mermaid\ngraph TD\n```';
-    const html = '<p>Math: $x^2$ and</p><pre><code class="language-mermaid">graph TD</code></pre>';
-
-    const result = await processRenderingExtensions(
-      markdown,
-      html,
-      { enableKatex: true, enableMermaid: true, enableMarp: false },
-      false,
-    );
-
-    expect(result.processedMarkdown).toContain('katex');
-    expect(result.processedHtml).toContain('mermaid-diagram');
-  });
-
-  it('skips KaTeX when disabled', async () => {
-    const markdown = 'Math: $x^2$';
-    const html = '<p>Math: $x^2$</p>';
-
-    const result = await processRenderingExtensions(
-      markdown,
-      html,
-      { enableKatex: false, enableMermaid: false, enableMarp: false },
-      false,
-    );
-
-    expect(result.processedMarkdown).toBe(markdown);
-    expect(result.processedHtml).toBe(html);
-  });
-
-  it('skips Mermaid when disabled', async () => {
-    const markdown = '```mermaid\ngraph TD\n```';
-    const html = '<pre><code class="language-mermaid">graph TD</code></pre>';
-
-    const result = await processRenderingExtensions(
-      markdown,
-      html,
-      { enableKatex: true, enableMermaid: false, enableMarp: false },
-      false,
-    );
-
-    expect(result.processedHtml).toBe(html);
-    expect(mockRender).not.toHaveBeenCalled();
-  });
-
-  it('skips processing when content has no matching syntax', async () => {
-    const markdown = 'Hello world';
-    const html = '<p>Hello world</p>';
-
-    const result = await processRenderingExtensions(
-      markdown,
-      html,
-      { enableKatex: true, enableMermaid: true, enableMarp: false },
-      false,
-    );
-
-    expect(result.processedMarkdown).toBe(markdown);
-    expect(result.processedHtml).toBe(html);
-  });
-});

--- a/src/utils/markdownRenderers.ts
+++ b/src/utils/markdownRenderers.ts
@@ -1,5 +1,4 @@
 import hljs from 'highlight.js';
-import type { RenderingSettings } from '../types/settings';
 
 /** Languages handled by post-processors — skip syntax highlighting */
 const POST_PROCESSED_LANGS = new Set(['mermaid']);
@@ -97,12 +96,37 @@ export function contentHasMermaid(content: string): boolean {
   return MERMAID_BLOCK_DETECT_RE.test(content);
 }
 
+/** Result of {@link processKatex}: placeholder-laden markdown plus a restore step. */
+export interface ProcessedKatex {
+  /** Markdown where each math expression is replaced by an inert placeholder token. */
+  markdown: string;
+  /** Swaps the placeholder tokens back to rendered KaTeX HTML (call after marked). */
+  restore: (html: string) => string;
+}
+
+// Placeholder token wrapping the math index. Intentionally pure [A-Za-z0-9] so
+// marked treats it as a plain word and never transforms it.
+const KATEX_PLACEHOLDER_RE = /KaTeXmathPLACEHOLDER(\d+)END/g;
+const makeKatexPlaceholder = (index: number) => `KaTeXmathPLACEHOLDER${index}END`;
+
 /**
- * Process KaTeX math expressions in markdown.
- * Returns the processed markdown with math rendered to HTML.
- * Code blocks are protected from processing.
+ * Render KaTeX math expressions in markdown, but DON'T inline the HTML — replace
+ * each expression with an inert placeholder and return a `restore()` that swaps
+ * the rendered HTML back in AFTER marked has run.
+ *
+ * Why placeholders instead of inlining the HTML before marked:
+ * KaTeX's output contains characters that are markdown-significant — most
+ * notably a literal tilde for accents (`\tilde` -> `<span class="mord">~</span>`,
+ * in both HTML and MathML output). When two such expressions share a document,
+ * marked's GFM strikethrough (`~...~`) pairs the tildes across expressions and
+ * injects unbalanced `<del>` tags INTO the rendered KaTeX markup, corrupting the
+ * DOM so the whole preview renders blank (issue #354). Keeping the rendered HTML
+ * out of marked's input entirely is the robust fix: marked only ever sees the
+ * alphanumeric placeholders, so no KaTeX output can collide with markdown syntax.
+ *
+ * Code blocks are protected so `$...$` inside them is left untouched.
  */
-export async function processKatex(markdown: string): Promise<string> {
+export async function processKatex(markdown: string): Promise<ProcessedKatex> {
   const katex = await getKatex();
 
   // Protect code blocks
@@ -112,30 +136,32 @@ export async function processKatex(markdown: string): Promise<string> {
     return `%%CODEBLOCK_${codeBlocks.length - 1}%%`;
   });
 
-  // Process display math ($$...$$) first
-  result = result.replace(DISPLAY_MATH_RE, (_match, tex: string) => {
+  const renderedMath: string[] = [];
+  const renderMath = (tex: string, displayMode: boolean): string => {
+    let html: string;
     try {
-      return katex.renderToString(tex.trim(), { displayMode: true, throwOnError: false }).replace(/\n/g, '');
+      html = katex.renderToString(tex.trim(), { displayMode, throwOnError: false }).replace(/\n/g, '');
     } catch {
-      return `<span class="katex-error" style="color:red;">${tex}</span>`;
+      html = `<span class="katex-error" style="color:red;">${tex}</span>`;
     }
-  });
+    const placeholder = makeKatexPlaceholder(renderedMath.length);
+    renderedMath.push(html);
+    return placeholder;
+  };
 
-  // Process inline math ($...$)
-  result = result.replace(INLINE_MATH_RE, (_match, tex: string) => {
-    try {
-      return katex.renderToString(tex.trim(), { displayMode: false, throwOnError: false }).replace(/\n/g, '');
-    } catch {
-      return `<span class="katex-error" style="color:red;">${tex}</span>`;
-    }
-  });
+  // Process display math ($$...$$) first, then inline ($...$).
+  result = result.replace(DISPLAY_MATH_RE, (_match, tex: string) => renderMath(tex, true));
+  result = result.replace(INLINE_MATH_RE, (_match, tex: string) => renderMath(tex, false));
 
   // Restore code blocks
   result = result.replace(/%%CODEBLOCK_(\d+)%%/g, (_match, index: string) => {
     return codeBlocks[parseInt(index)];
   });
 
-  return result;
+  const restore = (html: string): string =>
+    html.replace(KATEX_PLACEHOLDER_RE, (_match, index: string) => renderedMath[parseInt(index)] ?? '');
+
+  return { markdown: result, restore };
 }
 
 let mermaidCounter = 0;
@@ -231,31 +257,4 @@ async function processMermaidBlocksInternal(html: string, dark?: boolean): Promi
   }
 
   return result;
-}
-
-/**
- * Process markdown content with optional KaTeX and Mermaid rendering.
- * Only loads libraries when the feature is enabled AND the content uses them.
- */
-export async function processRenderingExtensions(
-  markdown: string,
-  html: string,
-  settings: RenderingSettings,
-  darkMode: boolean,
-): Promise<{ processedMarkdown: string; processedHtml: string }> {
-  let processedMarkdown = markdown;
-  let processedHtml = html;
-
-  // KaTeX: process markdown before marked
-  if (settings.enableKatex && contentHasKatex(markdown)) {
-    processedMarkdown = await processKatex(markdown);
-  }
-
-  // Mermaid: process HTML after marked (will be called separately)
-  if (settings.enableMermaid && contentHasMermaid(markdown)) {
-    reinitializeMermaid(darkMode);
-    processedHtml = await processMermaidBlocks(html, darkMode);
-  }
-
-  return { processedMarkdown, processedHtml };
 }


### PR DESCRIPTION
## Summary

KaTeX 0.17.0 crashed on accent commands with bold arguments (e.g. \tilde{\mathbf{x}}), and rendering KaTeX HTML before marked let math output collide with Markdown syntax —
corrupting the preview and tables. This PR pins KaTeX to the 0.16 line and reworks the math pipeline to shield KaTeX output from marked using placeholders, resolving issues #354
and #358.

## Changes

- Pin katex to ^0.16.22 (down from ^0.17.0) to avoid the 0.17.0 accent-rendering crash (TypeError: ...htmlBuilder), which throwOnError: false cannot suppress (#354).
- Ignore KaTeX minor/major bumps in Dependabot so the regression cannot return automatically (note: for a 0.x package, 0.16→0.17 is a minor bump).
- Rework processKatex to a "token shielding" model: math is replaced with inert alphanumeric placeholders before marked runs, and a returned restore() swaps the rendered KaTeX
HTML back in afterward. This keeps KaTeX output (accent tildes ~, absolute-value bars |, etc.) out of marked entirely, fixing blank previews (#354) and broken/altered tables
containing absolute values (#358).
- Apply restore() in both the preview render path and the HTML export path in Preview.tsx.
- Remove the now-unused processRenderingExtensions helper and its RenderingSettings import.

## Tests

- New src/utils/__tests__/katexRegression.test.ts: real-KaTeX (unmocked) regression suite covering #354 (accent commands render without throwing; two accent expressions don't produce stray del corruption) and #358 (absolute values keep tables intact and render as single bars rather than the norm \|).
- Updated src/utils/__tests__/markdownRenderers.test.ts: adapt processKatex tests to the new { markdown, restore } return shape, add a placeholder-shape assertion, and remove the
processRenderingExtensions describe block.
- Updated src/components/__tests__/Preview.test.tsx: update the processKatex mock to mirror the placeholder/restore contract.