### PR TITLE
Fix tab and table-row drag not starting on quick grab-and-drag

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -81,9 +81,12 @@ interface TabBarProps {
 const createThresholdPointerSensor = () => {
   return useSensor(PointerSensor, {
     activationConstraint: {
+      // Use a distance-only constraint. Combining `distance` with `delay`
+      // makes dnd-kit treat it as a press-and-hold (delay) constraint and
+      // cancel the drag if the pointer moves beyond `tolerance` before the
+      // delay elapses, so a quick grab-and-drag never starts. Distance alone
+      // means: move beyond the threshold to start dragging, otherwise it's a click.
       distance: dragConfig.dragThreshold,
-      delay: dragConfig.dragDelay,
-      tolerance: 3,
     },
   });
 };

--- a/src/components/TableEditModal.tsx
+++ b/src/components/TableEditModal.tsx
@@ -151,9 +151,9 @@ const TableEditModal: React.FC<TableEditModalProps> = ({ table, onApply, onClose
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
+        // Distance-only constraint (see TabBar.tsx): combining `distance` with
+        // `delay` makes dnd-kit cancel a quick grab-and-drag before it starts.
         distance: dragConfig.dragThreshold,
-        delay: dragConfig.dragDelay,
-        tolerance: 3,
       },
     }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),

--- a/src/config/dragConfig.ts
+++ b/src/config/dragConfig.ts
@@ -5,10 +5,6 @@ export const dragConfig = {
   // Drag start threshold (pixels)
   // Dragging only starts when the mouse moves beyond this distance
   dragThreshold: 8,
-
-  // Drag start delay (milliseconds)
-  // Dragging only starts if the threshold is exceeded within this time
-  dragDelay: 150,
 } as const;
 
 export type DragConfig = typeof dragConfig;


### PR DESCRIPTION
## Summary

Dragging tabs (and rows/columns in the table editor) failed to start when the
user performed a quick grab-and-drag. This fixes the drag activation by
switching the dnd-kit pointer sensor to a distance-only activation constraint.

## Root cause

The `PointerSensor` was configured with both `distance` and `delay` activation
constraints. When `delay` is combined with `distance`, dnd-kit treats the
constraint as a press-and-hold (delay) constraint: if the pointer moves beyond
`tolerance` (3px) before the delay elapses, the drag is cancelled. As a result,
a fast grab-and-drag never started a drag — it was always interpreted as a
click.

## Changes

- `src/components/TabBar.tsx`: Use a distance-only activation constraint for the
tab drag sensor (removed `delay` and `tolerance`).
- `src/components/TableEditModal.tsx`: Apply the same distance-only constraint to
the table editor drag sensor.
- `src/config/dragConfig.ts`: Remove the now-unused `dragDelay` config value.

With a distance-only constraint, moving the pointer beyond `dragThreshold` (8px)
starts the drag; anything less is treated as a click.