### PR TITLE
Add arm64 (Raspberry Pi) Linux build and fix DMABUF rendering

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -66,3 +66,57 @@ jobs:
           fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Separate arm64 job for Raspberry Pi (deb only, no updater/signing).
+  # Built natively on a GitHub-hosted arm64 runner. ubuntu-22.04-arm ships
+  # glibc 2.35, which keeps the deb runnable on Raspberry Pi OS Bookworm
+  # (glibc 2.36); a newer runner (24.04 / glibc 2.39) would not run there.
+  build-linux-arm64:
+    runs-on: ubuntu-22.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Build application (deb only)
+        run: npm run tauri:build -- --target aarch64-unknown-linux-gnu --bundles deb
+
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            ./src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/deb/Bokuchi_${{ steps.version.outputs.version }}_arm64.deb
+          fail_on_unmatched_files: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,8 +45,44 @@ pub use file_association::*;
 // Re-export commands
 pub use commands::*;
 
+/// Work around corrupted rendering on Raspberry Pi.
+///
+/// WebKitGTK >= 2.42 enables a DMABUF-based GPU renderer by default. On the
+/// Raspberry Pi (VideoCore / V3D driver) this produces garbled, scanline-like
+/// noise instead of the UI. The failure is silent — rendering "succeeds" and
+/// only the result is broken — so it cannot be detected after the fact. We
+/// instead detect the known-bad environment (a Pi) up front and disable the
+/// DMABUF renderer before WebKitGTK is initialized.
+///
+/// Must run before any webview is created (i.e. before `tauri::Builder`).
+#[cfg(target_os = "linux")]
+fn workaround_webkit_dmabuf() {
+    // Respect an explicit user setting (escape hatch to force-enable on a
+    // normal desktop, or force-disable elsewhere).
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_some() {
+        return;
+    }
+
+    // The Raspberry Pi exposes its model name via the device tree.
+    let is_raspberry_pi = std::fs::read_to_string("/proc/device-tree/model")
+        .map(|model| model.contains("Raspberry Pi"))
+        .unwrap_or(false);
+
+    if is_raspberry_pi {
+        // SAFETY: called at the very start of `run()`, before Tauri spawns any
+        // threads, so there is no concurrent access to the environment.
+        unsafe {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+        println!("Detected Raspberry Pi: disabled WebKitGTK DMABUF renderer");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    workaround_webkit_dmabuf();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {


### PR DESCRIPTION
## Summary

Adds a Raspberry Pi (arm64) Linux release build and fixes the garbled, scanline-like rendering that WebKitGTK's DMABUF renderer produces on the Pi's GPU. Existing x86_64 release
artifacts are left unchanged.

## Changes

- Detect Raspberry Pi at startup (via /proc/device-tree/model) and disable the WebKitGTK DMABUF renderer before the webview is created, working around silent GPU-rendering
corruption on the Pi. An explicit WEBKIT_DISABLE_DMABUF_RENDERER setting is respected as an escape hatch, and the workaround is Linux-only.
- Add a separate build-linux-arm64 CI job that natively builds an arm64 .deb on the ubuntu-22.04-arm runner (glibc 2.35, chosen for compatibility with Raspberry Pi OS Bookworm) and
uploads it to the release. The job builds deb only with no updater/signing, and the existing x86_64 job (deb/rpm/AppImage) is untouched.

## Tests

No test changes. The Raspberry Pi workaround is #[cfg(target_os = "linux")] and the arm64 build is exercised by CI on release; neither is covered by unit tests.