### PR TITLE
Refactor Editor, SearchReplacePanel & App into testable units

### DIFF
--- a/src-tauri/src/pdf_export.rs
+++ b/src-tauri/src/pdf_export.rs
@@ -345,8 +345,8 @@ fn print_platform_webview(
         let uri = url::Url::from_file_path(output_path)
             .map_err(|_| "invalid output path".to_string())?
             .to_string();
-        settings.set("output-uri", &uri);
-        settings.set("output-file-format", "pdf");
+        settings.set("output-uri", Some(uri.as_str()));
+        settings.set("output-file-format", Some("pdf"));
         print_op.set_print_settings(&settings);
 
         let done_finished = done.clone();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { CssBaseline, Box, Typography, IconButton, Tooltip } from '@mui/material';
-import { Close, Fullscreen, FullscreenExit } from '@mui/icons-material';
+import { CssBaseline, Box, Typography } from '@mui/material';
 
 import AppHeader from './components/AppHeader';
 import AppContent from './components/AppContent';
@@ -9,10 +8,12 @@ import AppDialogs from './components/AppDialogs';
 import StatusBar from './components/StatusBar';
 import RecentFilesDialog from './components/RecentFilesDialog';
 import RenameDialog from './components/RenameDialog';
+import RinControls from './components/RinControls';
+import KonamiUnlockOverlay from './components/KonamiUnlockOverlay';
 import { useAppState } from './hooks/useAppState';
 import { useRinExitButton } from './hooks/useRinExitButton';
+import { useDesktopEventListeners } from './hooks/useDesktopEventListeners';
 import { isDarkTheme } from './themes';
-import { isImageFilePath } from './utils/imageInsertion';
 import './i18n';
 import './styles/variables.css';
 import './styles/base.css';
@@ -163,190 +164,12 @@ function AppDesktop() {
     appSettings.interface.outlineEnabled &&
     (appSettings.interface.outlineDisplayMode === 'overlay' ? outlinePanelOpen : true);
 
-  // Track whether event listeners are fully registered
-  const [listenersReady, setListenersReady] = useState(false);
-
-  // Ref to always hold the latest handlers, avoiding stale closures in event listeners
-  const handlersRef = useRef({
+  // Register menu / file-association / drag-drop listeners once and learn when
+  // they are ready. Handlers are read via a live ref inside the hook.
+  const listenersReady = useDesktopEventListeners({
     handleNewTab, handleSaveFile, handleSaveFileAs, handleSaveWithVariables,
     handleHelpOpen, openFile, requestEditorFocus, setIsDragOver, setSnackbar, t,
   });
-  useEffect(() => {
-    handlersRef.current = {
-      handleNewTab, handleSaveFile, handleSaveFileAs, handleSaveWithVariables,
-      handleHelpOpen, openFile, requestEditorFocus, setIsDragOver, setSnackbar, t,
-    };
-  });
-
-  // Set up menu event listeners
-  useEffect(() => {
-    let cancelled = false;
-
-    let unlistenMenu: (() => void) | undefined;
-    let unlistenNewFile: (() => void) | undefined;
-    let unlistenOpenFile: (() => void) | undefined;
-    let unlistenSaveAs: (() => void) | undefined;
-    let unlistenSaveWithVariables: (() => void) | undefined;
-    let unlistenHelp: (() => void) | undefined;
-    let unlistenFileOpen: (() => void) | undefined;
-    let unlistenDragDrop: (() => void) | undefined;
-
-    const setupMenuListeners = async () => {
-      const { listen } = await import('@tauri-apps/api/event');
-
-      // If effect was cleaned up during the async import, don't register listeners
-      if (cancelled) return;
-
-      const MENU_DEBOUNCE_MS = 100;
-      const FILE_OPEN_DEBOUNCE_MS = 2000;
-
-      // Shared debounce state for menu events (attached to window to survive re-renders)
-      const globalDebounce = (window as unknown as {
-        lastMenuEventTime?: number;
-      });
-
-      if (!globalDebounce.lastMenuEventTime) {
-        globalDebounce.lastMenuEventTime = 0;
-      }
-
-      // Returns true if the event should be suppressed (within debounce window)
-      const isMenuDebounced = (): boolean => {
-        const now = Date.now();
-        if (now - globalDebounce.lastMenuEventTime! < MENU_DEBOUNCE_MS) {
-          return true;
-        }
-        globalDebounce.lastMenuEventTime = now;
-        return false;
-      };
-
-      unlistenMenu = await listen('menu-save', () => {
-        if (!isMenuDebounced()) handlersRef.current.handleSaveFile();
-      });
-
-      unlistenNewFile = await listen('menu-new-file', () => {
-        if (!isMenuDebounced()) handlersRef.current.handleNewTab();
-      });
-
-      unlistenOpenFile = await listen('menu-open-file', async () => {
-        if (isMenuDebounced()) return;
-        try {
-          await handlersRef.current.openFile();
-        } catch (error) {
-          console.error('Failed to open file from menu:', error);
-        }
-      });
-
-      unlistenSaveAs = await listen('menu-save-as', () => {
-        if (!isMenuDebounced()) handlersRef.current.handleSaveFileAs();
-      });
-
-      unlistenSaveWithVariables = await listen('menu-save-with-variables', () => {
-        if (!isMenuDebounced()) handlersRef.current.handleSaveWithVariables();
-      });
-
-      unlistenHelp = await listen('menu-help', () => {
-        if (!isMenuDebounced()) handlersRef.current.handleHelpOpen();
-      });
-
-      // File association event listener with debounce
-      const fileOpenDebounce = (window as unknown as {
-        lastFileOpenTime?: number;
-        lastFilePath?: string;
-      });
-
-      if (!fileOpenDebounce.lastFileOpenTime) {
-        fileOpenDebounce.lastFileOpenTime = 0;
-      }
-      if (!fileOpenDebounce.lastFilePath) {
-        fileOpenDebounce.lastFilePath = '';
-      }
-
-      unlistenFileOpen = await listen('open-file', async (event: { payload: { file_path: string } }) => {
-        const now = Date.now();
-        const timeDiff = now - fileOpenDebounce.lastFileOpenTime!;
-        const currentFilePath = event.payload.file_path;
-        const isSameFile = currentFilePath === fileOpenDebounce.lastFilePath;
-
-        // Debounce: same file within time limit
-        if (isSameFile && timeDiff < FILE_OPEN_DEBOUNCE_MS) {
-          return;
-        }
-        fileOpenDebounce.lastFileOpenTime = now;
-        fileOpenDebounce.lastFilePath = currentFilePath;
-        await handlersRef.current.openFile(currentFilePath);
-        handlersRef.current.requestEditorFocus();
-      });
-
-      // Drag and drop event listener (uses Tauri API to get file paths)
-      const { getCurrentWebview } = await import('@tauri-apps/api/webview');
-      if (cancelled) return;
-
-      const isSupportedFile = (path: string) => {
-        const lower = path.toLowerCase();
-        return lower.endsWith('.md') || lower.endsWith('.markdown') || lower.endsWith('.txt');
-      };
-
-      unlistenDragDrop = await getCurrentWebview().onDragDropEvent(async (event) => {
-        if (event.payload.type === 'enter') {
-          const hasSupported = event.payload.paths.some(isSupportedFile);
-          if (hasSupported) {
-            handlersRef.current.setIsDragOver(true);
-          }
-        } else if (event.payload.type === 'leave') {
-          handlersRef.current.setIsDragOver(false);
-        } else if (event.payload.type === 'drop') {
-          handlersRef.current.setIsDragOver(false);
-          const supportedPaths = event.payload.paths.filter(isSupportedFile);
-          if (supportedPaths.length === 0) {
-            // Image drops are handled by the editor's own drag-drop listener
-            // (inserted as Markdown links), so don't treat them as an error here.
-            const hasImage = event.payload.paths.some(isImageFilePath);
-            if (!hasImage) {
-              handlersRef.current.setSnackbar({
-                open: true,
-                message: handlersRef.current.t('fileOperations.noMarkdownFiles'),
-                severity: 'error',
-              });
-            }
-            return;
-          }
-
-          // Mark in fileOpenDebounce so the subsequent RunEvent::Opened
-          // (which macOS also fires for dropped files) is suppressed
-          fileOpenDebounce.lastFileOpenTime = Date.now();
-          fileOpenDebounce.lastFilePath = supportedPaths[0];
-
-          try {
-            await handlersRef.current.openFile(supportedPaths[0]);
-            handlersRef.current.requestEditorFocus();
-          } catch {
-            handlersRef.current.setSnackbar({
-              open: true,
-              message: handlersRef.current.t('fileOperations.fileLoadFailed'),
-              severity: 'error',
-            });
-          }
-        }
-      });
-
-      // Signal that all listeners are registered
-      setListenersReady(true);
-    };
-
-    setupMenuListeners();
-
-    return () => {
-      cancelled = true;
-      if (unlistenMenu) unlistenMenu();
-      if (unlistenNewFile) unlistenNewFile();
-      if (unlistenOpenFile) unlistenOpenFile();
-      if (unlistenSaveAs) unlistenSaveAs();
-      if (unlistenSaveWithVariables) unlistenSaveWithVariables();
-      if (unlistenHelp) unlistenHelp();
-      if (unlistenFileOpen) unlistenFileOpen();
-      if (unlistenDragDrop) unlistenDragDrop();
-    };
-  }, []); // Empty dependency array to run only once
 
   // Notify Rust that frontend is ready AFTER both conditions are met:
   // 1. State restoration is complete (isInitialized) — prevents LOAD_STATE from overwriting file association tabs
@@ -517,49 +340,14 @@ function AppDesktop() {
           t={t}
         />
 
-        {/* 臨 (Rin) focus-mode controls: shown on mouse-move, fade over 3s while typing.
-            Stacked top-right (exit on top, width toggle below). */}
         {rinActive && (
-          <>
-            <Tooltip title={t('rin.exit')} placement="left">
-              <IconButton
-                onClick={exitRin}
-                aria-label={t('rin.exit')}
-                sx={{
-                  position: 'fixed',
-                  top: 12,
-                  right: 12,
-                  zIndex: 1300,
-                  bgcolor: 'action.selected',
-                  opacity: rinExitVisible ? 1 : 0,
-                  pointerEvents: rinExitVisible ? 'auto' : 'none',
-                  transition: rinExitVisible ? 'opacity 0.15s ease' : 'opacity 3s ease',
-                  '&:hover': { bgcolor: 'action.focus' },
-                }}
-              >
-                <Close />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('rin.toggleWidth')} placement="left">
-              <IconButton
-                onClick={() => setRinFullWidth((v) => !v)}
-                aria-label={t('rin.toggleWidth')}
-                sx={{
-                  position: 'fixed',
-                  top: 56,
-                  right: 12,
-                  zIndex: 1300,
-                  bgcolor: 'action.selected',
-                  opacity: rinExitVisible ? 1 : 0,
-                  pointerEvents: rinExitVisible ? 'auto' : 'none',
-                  transition: rinExitVisible ? 'opacity 0.15s ease' : 'opacity 3s ease',
-                  '&:hover': { bgcolor: 'action.focus' },
-                }}
-              >
-                {rinFullWidth ? <FullscreenExit /> : <Fullscreen />}
-              </IconButton>
-            </Tooltip>
-          </>
+          <RinControls
+            visible={rinExitVisible}
+            fullWidth={rinFullWidth}
+            onExit={exitRin}
+            onToggleWidth={() => setRinFullWidth((v) => !v)}
+            t={t}
+          />
         )}
 
         {(!isInitialized || !isSettingsLoaded) && (
@@ -651,83 +439,7 @@ function AppDesktop() {
         />
       )}
       {/* Konami Code unlock animation */}
-      {showUnlockAnimation && (
-        <Box
-          sx={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            pointerEvents: 'none',
-            zIndex: 9999,
-            animation: 'konamiUnlock 2.5s ease-out forwards',
-            '@keyframes konamiUnlock': {
-              '0%': {
-                backgroundColor: 'rgba(0, 255, 0, 0)',
-                boxShadow: 'inset 0 0 0px rgba(0, 255, 0, 0)',
-              },
-              '15%': {
-                backgroundColor: 'rgba(0, 255, 0, 0.15)',
-                boxShadow: 'inset 0 0 60px rgba(0, 255, 0, 0.4)',
-              },
-              '30%': {
-                backgroundColor: 'rgba(0, 255, 0, 0.05)',
-                boxShadow: 'inset 0 0 30px rgba(0, 255, 0, 0.2)',
-              },
-              '45%': {
-                backgroundColor: 'rgba(0, 255, 0, 0.1)',
-                boxShadow: 'inset 0 0 40px rgba(0, 255, 0, 0.3)',
-              },
-              '100%': {
-                backgroundColor: 'rgba(0, 255, 0, 0)',
-                boxShadow: 'inset 0 0 0px rgba(0, 255, 0, 0)',
-              },
-            },
-          }}
-        >
-          {/* Scanline effect */}
-          <Box
-            sx={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              background: 'repeating-linear-gradient(0deg, rgba(0,255,0,0.03) 0px, rgba(0,255,0,0.03) 1px, transparent 1px, transparent 3px)',
-              animation: 'scanlineScroll 0.1s linear infinite',
-              '@keyframes scanlineScroll': {
-                '0%': { backgroundPosition: '0 0' },
-                '100%': { backgroundPosition: '0 3px' },
-              },
-            }}
-          />
-          {/* Theme unlocked text */}
-          <Typography
-            sx={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              color: '#00FF00',
-              fontFamily: '"IBM Plex Mono", "Courier New", Courier, monospace',
-              fontSize: '24px',
-              fontWeight: 'bold',
-              textShadow: '0 0 10px rgba(0,255,0,0.8), 0 0 20px rgba(0,255,0,0.4)',
-              animation: 'unlockTextFade 2.5s ease-out forwards',
-              whiteSpace: 'nowrap',
-              '@keyframes unlockTextFade': {
-                '0%': { opacity: 0 },
-                '20%': { opacity: 1 },
-                '70%': { opacity: 1 },
-                '100%': { opacity: 0 },
-              },
-            }}
-          >
-            {'> AS/400 THEME UNLOCKED_'}
-          </Typography>
-        </Box>
-      )}
+      {showUnlockAnimation && <KonamiUnlockOverlay />}
       </Box>
     </ThemeProvider>
   );

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -6,15 +6,12 @@ import { Search } from '@mui/icons-material';
 import SearchReplacePanel from './SearchReplacePanel';
 import { useTranslation } from 'react-i18next';
 import { TableConversionDialog } from './TableConversionDialog';
-import { htmlTableToMarkdown, validateMarkdownTable, convertTsvCsvToMarkdown } from '../utils/tableConverter';
 import MarkdownToolbar from './MarkdownToolbar';
 import { Tab } from '../types/tab';
 import { findModelForTab, isModelSilentlyEditing } from '../utils/editorSync';
-import { findTableBlock, isTableSeparatorLine } from '../utils/tableFormatter';
-import { formatTableInEditor, handleTableEnter, handleTableTab } from '../utils/tableEditorActions';
-import { handleListEnter, handleListIndent } from '../utils/listEditorActions';
-import { parseListItem } from '../utils/listFormatter';
-import { countWords } from '../utils/wordCount';
+import { registerEditorActions } from '../utils/registerEditorActions';
+import { classifyPaste } from '../utils/pasteClassifier';
+import { computeEditorStatus } from '../utils/editorStatus';
 import { desktopApi } from '../api/desktopApi';
 import {
   IMAGE_SUBDIR,
@@ -335,27 +332,12 @@ const MarkdownEditor: React.FC<EditorProps> = ({
         return;
       }
 
-      let markdownTable = '';
-
-      // Step 1: Search and convert HTML tables
-      if (htmlData && htmlData.includes('<table') && htmlData.includes('</table>')) {
-        markdownTable = htmlTableToMarkdown(htmlData);
-      }
-      // Step 2: Search and convert TSV/CSV in plain text
-      else if (plainText && (plainText.includes('\t') || plainText.includes(','))) {
-        markdownTable = convertTsvCsvToMarkdown(plainText);
-      }
-      else {
+      const classification = classifyPaste(htmlData, plainText);
+      if (classification.kind === 'plain') {
         insertPlainText(plainText);
         return;
       }
-
-      // Validate conversion result
-      if (!validateMarkdownTable(markdownTable)) {
-        insertPlainText(plainText);
-        return;
-      }
-
+      const { markdownTable } = classification;
 
       // Process according to settings
       if (tableConversion === 'auto') {
@@ -363,16 +345,12 @@ const MarkdownEditor: React.FC<EditorProps> = ({
         insertMarkdownTable(markdownTable);
         onSnackbar?.(t('tableConversion.conversionSuccess'), 'success');
       } else if (tableConversion === 'confirm') {
-        // Show confirmation dialog
-        // Save clipboard data immediately (save data, not object)
-        const savedData = {
-          plainText: plainText,
-          htmlData: htmlData
-        };
+        // Show confirmation dialog. Save the clipboard data (a copy, not the
+        // event object) so it survives until the user decides.
         setTableConversionDialog({
           open: true,
           markdownTable,
-          clipboardData: savedData,
+          clipboardData: { plainText, htmlData },
         });
       }
     } catch (error) {
@@ -591,7 +569,7 @@ const MarkdownEditor: React.FC<EditorProps> = ({
     disposablesRef.current.forEach(d => d.dispose());
     disposablesRef.current = [];
 
-    // Set up search and replace keyboard shortcuts
+    // Register search shortcuts and smart table/list editing actions.
     try {
       // Prefer the monaco namespace from @monaco-editor/react's onMount
       // argument; it is always provided at runtime, which avoids the
@@ -600,185 +578,25 @@ const MarkdownEditor: React.FC<EditorProps> = ({
       // invoke onMount without the argument (e.g. the test harness).
       const monaco = monacoNs || (window as { monaco?: typeof import('monaco-editor') }).monaco;
       if (monaco) {
-        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {
-          setSearchAllTabsDefault(false);
-          setShowReplaceDefault(false);
-          setSearchOpen(true);
-        });
-
-        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyH, () => {
-          setSearchAllTabsDefault(false);
-          setShowReplaceDefault(true);
-          setSearchOpen(true);
-        });
-
-        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyF, () => {
-          setSearchAllTabsDefault(true);
-          setShowReplaceDefault(false);
-          setSearchOpen(true);
-        });
-
-        // Completely disable default behavior of Shift + Cmd/Ctrl + V
-        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyV, () => {
-          // Do nothing (completely disable default "Paste as Plain Text")
-        });
-
-        // Disable with a more powerful method
-        editor.addAction({
-          id: 'disable-shift-v',
-          label: 'Disable Shift+V',
-          keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyV],
-          run: () => {
-            // Do nothing
-          }
-        });
-
-        // --- Markdown table editing (#5 format, #6 Enter, #7 Tab) ---
-
-        // #5: Format the table block at the cursor.
-        editor.addAction({
-          id: 'format-markdown-table',
-          label: 'Format Markdown Table',
-          keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyL],
-          run: (ed) => {
-            formatTableInEditor(ed as editor.IStandaloneCodeEditor);
-          },
-        });
-
-        // Context key gating Enter/Tab overrides. It is set to false while an
-        // IME composition is active so Japanese conversion (Enter to confirm)
-        // and default Tab are never hijacked.
-        const inTableRowKey = editor.createContextKey<boolean>('bokuchiInTableRow', false);
-        const inListItemKey = editor.createContextKey<boolean>('bokuchiInListItem', false);
-        let isComposing = false;
-
-        const clearEditingContext = () => {
-          inTableRowKey.set(false);
-          inListItemKey.set(false);
-        };
-
-        const updateEditingContext = () => {
-          if (isComposing) {
-            clearEditingContext();
-            return;
-          }
-          const model = editor.getModel();
-          const pos = editor.getPosition();
-          if (!model || !pos) {
-            clearEditingContext();
-            return;
-          }
-          const lineContent = model.getLineContent(pos.lineNumber);
-          const block = findTableBlock(model.getLinesContent(), pos.lineNumber);
-          const inRow = !!block && !isTableSeparatorLine(lineContent);
-          inTableRowKey.set(inRow);
-          // A table row is never treated as a list item (mutually exclusive
-          // preconditions so Enter/Tab dispatch to a single handler).
-          inListItemKey.set(!inRow && parseListItem(lineContent) !== null);
-        };
-
         disposablesRef.current.push(
-          editor.onDidCompositionStart(() => {
-            isComposing = true;
-            clearEditingContext();
+          ...registerEditorActions(editor, monaco, {
+            openSearch: () => {
+              setSearchAllTabsDefault(false);
+              setShowReplaceDefault(false);
+              setSearchOpen(true);
+            },
+            openReplace: () => {
+              setSearchAllTabsDefault(false);
+              setShowReplaceDefault(true);
+              setSearchOpen(true);
+            },
+            openSearchAllTabs: () => {
+              setSearchAllTabsDefault(true);
+              setShowReplaceDefault(false);
+              setSearchOpen(true);
+            },
           }),
         );
-        disposablesRef.current.push(
-          editor.onDidCompositionEnd(() => {
-            isComposing = false;
-            updateEditingContext();
-          }),
-        );
-        disposablesRef.current.push(editor.onDidChangeCursorPosition(updateEditingContext));
-        disposablesRef.current.push(editor.onDidChangeModelContent(updateEditingContext));
-        updateEditingContext();
-
-        // #6: Enter adds a new row / exits the table when on an empty row.
-        // If the handler declines (e.g. an active selection), fall back to a
-        // normal newline so the key is never swallowed.
-        editor.addAction({
-          id: 'table-enter-new-row',
-          label: 'Table: New Row',
-          keybindings: [monaco.KeyCode.Enter],
-          precondition: 'bokuchiInTableRow',
-          run: (ed) => {
-            const e = ed as editor.IStandaloneCodeEditor;
-            if (!handleTableEnter(e)) {
-              e.trigger('keyboard', 'type', { text: '\n' });
-            }
-          },
-        });
-
-        // #7: Tab / Shift+Tab move between cells; fall back to default
-        // indent/outdent when the handler declines.
-        editor.addAction({
-          id: 'table-next-cell',
-          label: 'Table: Next Cell',
-          keybindings: [monaco.KeyCode.Tab],
-          precondition: 'bokuchiInTableRow',
-          run: (ed) => {
-            const e = ed as editor.IStandaloneCodeEditor;
-            if (!handleTableTab(e, false)) {
-              e.trigger('keyboard', 'tab', null);
-            }
-          },
-        });
-        editor.addAction({
-          id: 'table-prev-cell',
-          label: 'Table: Previous Cell',
-          keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Tab],
-          precondition: 'bokuchiInTableRow',
-          run: (ed) => {
-            const e = ed as editor.IStandaloneCodeEditor;
-            if (!handleTableTab(e, true)) {
-              e.trigger('keyboard', 'outdent', null);
-            }
-          },
-        });
-
-        // --- Smart Markdown list editing (Enter continuation, Tab indent) ---
-
-        // Enter continues the list (or ends it on an empty item). Fall back to a
-        // normal newline when the handler declines (e.g. active selection).
-        editor.addAction({
-          id: 'list-enter-continue',
-          label: 'List: Continue Item',
-          keybindings: [monaco.KeyCode.Enter],
-          precondition: 'bokuchiInListItem',
-          run: (ed) => {
-            const e = ed as editor.IStandaloneCodeEditor;
-            if (!handleListEnter(e)) {
-              e.trigger('keyboard', 'type', { text: '\n' });
-            }
-          },
-        });
-
-        // Tab / Shift+Tab indent or outdent the list item; fall back to the
-        // default indent/outdent when the handler declines.
-        editor.addAction({
-          id: 'list-indent',
-          label: 'List: Indent Item',
-          keybindings: [monaco.KeyCode.Tab],
-          precondition: 'bokuchiInListItem',
-          run: (ed) => {
-            const e = ed as editor.IStandaloneCodeEditor;
-            if (!handleListIndent(e, false)) {
-              e.trigger('keyboard', 'tab', null);
-            }
-          },
-        });
-        editor.addAction({
-          id: 'list-outdent',
-          label: 'List: Outdent Item',
-          keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Tab],
-          precondition: 'bokuchiInListItem',
-          run: (ed) => {
-            const e = ed as editor.IStandaloneCodeEditor;
-            if (!handleListIndent(e, true)) {
-              e.trigger('keyboard', 'outdent', null);
-            }
-          },
-        });
       }
     } catch (error) {
       console.warn('Failed to set keyboard shortcuts:', error);
@@ -792,26 +610,8 @@ const MarkdownEditor: React.FC<EditorProps> = ({
         const model = editor.getModel();
 
         if (position && model) {
-          const fullText = model.getValue();
-          const totalCharacters = fullText.length;
-          const totalWords = countWords(fullText);
-          let selectedCharacters = 0;
-          let selectedWords = 0;
-
-          if (selection) {
-            const selectedText = model.getValueInRange(selection);
-            selectedCharacters = selectedText.length;
-            selectedWords = countWords(selectedText);
-          }
-
-          onStatusChange({
-            line: position.lineNumber,
-            column: position.column,
-            totalCharacters,
-            selectedCharacters,
-            totalWords,
-            selectedWords
-          });
+          const selectedText = selection ? model.getValueInRange(selection) : '';
+          onStatusChange(computeEditorStatus(model.getValue(), selectedText, position));
         }
       };
 

--- a/src/components/KonamiUnlockOverlay.tsx
+++ b/src/components/KonamiUnlockOverlay.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+/**
+ * Full-screen retro "AS/400 THEME UNLOCKED" flash played once when the Konami
+ * code unlocks the hidden theme. Purely decorative and non-interactive.
+ */
+const KonamiUnlockOverlay: React.FC = () => (
+  <Box
+    sx={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      pointerEvents: 'none',
+      zIndex: 9999,
+      animation: 'konamiUnlock 2.5s ease-out forwards',
+      '@keyframes konamiUnlock': {
+        '0%': {
+          backgroundColor: 'rgba(0, 255, 0, 0)',
+          boxShadow: 'inset 0 0 0px rgba(0, 255, 0, 0)',
+        },
+        '15%': {
+          backgroundColor: 'rgba(0, 255, 0, 0.15)',
+          boxShadow: 'inset 0 0 60px rgba(0, 255, 0, 0.4)',
+        },
+        '30%': {
+          backgroundColor: 'rgba(0, 255, 0, 0.05)',
+          boxShadow: 'inset 0 0 30px rgba(0, 255, 0, 0.2)',
+        },
+        '45%': {
+          backgroundColor: 'rgba(0, 255, 0, 0.1)',
+          boxShadow: 'inset 0 0 40px rgba(0, 255, 0, 0.3)',
+        },
+        '100%': {
+          backgroundColor: 'rgba(0, 255, 0, 0)',
+          boxShadow: 'inset 0 0 0px rgba(0, 255, 0, 0)',
+        },
+      },
+    }}
+  >
+    {/* Scanline effect */}
+    <Box
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'repeating-linear-gradient(0deg, rgba(0,255,0,0.03) 0px, rgba(0,255,0,0.03) 1px, transparent 1px, transparent 3px)',
+        animation: 'scanlineScroll 0.1s linear infinite',
+        '@keyframes scanlineScroll': {
+          '0%': { backgroundPosition: '0 0' },
+          '100%': { backgroundPosition: '0 3px' },
+        },
+      }}
+    />
+    {/* Theme unlocked text */}
+    <Typography
+      sx={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        color: '#00FF00',
+        fontFamily: '"IBM Plex Mono", "Courier New", Courier, monospace',
+        fontSize: '24px',
+        fontWeight: 'bold',
+        textShadow: '0 0 10px rgba(0,255,0,0.8), 0 0 20px rgba(0,255,0,0.4)',
+        animation: 'unlockTextFade 2.5s ease-out forwards',
+        whiteSpace: 'nowrap',
+        '@keyframes unlockTextFade': {
+          '0%': { opacity: 0 },
+          '20%': { opacity: 1 },
+          '70%': { opacity: 1 },
+          '100%': { opacity: 0 },
+        },
+      }}
+    >
+      {'> AS/400 THEME UNLOCKED_'}
+    </Typography>
+  </Box>
+);
+
+export default KonamiUnlockOverlay;

--- a/src/components/RinControls.tsx
+++ b/src/components/RinControls.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import { Close, Fullscreen, FullscreenExit } from '@mui/icons-material';
+
+interface RinControlsProps {
+  /** Whether the controls are visible (mouse-move shows, typing fades them). */
+  visible: boolean;
+  /** Whether the editor is currently full-width (vs. 1000px centered). */
+  fullWidth: boolean;
+  onExit: () => void;
+  onToggleWidth: () => void;
+  t: (key: string) => string;
+}
+
+const fixedButtonSx = (visible: boolean, top: number) => ({
+  position: 'fixed' as const,
+  top,
+  right: 12,
+  zIndex: 1300,
+  bgcolor: 'action.selected',
+  opacity: visible ? 1 : 0,
+  pointerEvents: visible ? ('auto' as const) : ('none' as const),
+  // Show quickly on activity; fade slowly while typing.
+  transition: visible ? 'opacity 0.15s ease' : 'opacity 3s ease',
+  '&:hover': { bgcolor: 'action.focus' },
+});
+
+/**
+ * 臨 (Rin) focus-mode controls: an exit button and an editor-width toggle,
+ * stacked top-right. Shown on mouse-move and faded while typing.
+ */
+const RinControls: React.FC<RinControlsProps> = ({ visible, fullWidth, onExit, onToggleWidth, t }) => (
+  <>
+    <Tooltip title={t('rin.exit')} placement="left">
+      <IconButton onClick={onExit} aria-label={t('rin.exit')} sx={fixedButtonSx(visible, 12)}>
+        <Close />
+      </IconButton>
+    </Tooltip>
+    <Tooltip title={t('rin.toggleWidth')} placement="left">
+      <IconButton onClick={onToggleWidth} aria-label={t('rin.toggleWidth')} sx={fixedButtonSx(visible, 56)}>
+        {fullWidth ? <FullscreenExit /> : <Fullscreen />}
+      </IconButton>
+    </Tooltip>
+  </>
+);
+
+export default RinControls;

--- a/src/components/SearchReplacePanel.tsx
+++ b/src/components/SearchReplacePanel.tsx
@@ -10,26 +10,23 @@ import {
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { Tab } from '../types/tab';
+import SearchMatchRow from './search/SearchMatchRow';
+import {
+  buildSearchRegex,
+  iterateMatches,
+  searchAcrossTabs,
+  pickNearestMatchIndex,
+  snippetParts,
+  type MatchInfo,
+  type CrossTabMatchInfo,
+} from '../utils/searchMatches';
 
-interface MatchInfo {
-  range: {
-    startLineNumber: number;
-    startColumn: number;
-    endLineNumber: number;
-    endColumn: number;
-  };
-  text: string;
-  lineContent: string;
-}
-
-interface CrossTabMatchInfo {
-  tabId: string;
-  tabTitle: string;
-  lineNumber: number;
-  column: number;
-  text: string;
-  lineContent: string;
-}
+/** Delay before focusing the search input so it wins over Monaco's focus. */
+const FOCUS_DELAY_MS = 50;
+/** Wait for the editor to remount after switching tabs before revealing a match. */
+const TAB_SWITCH_REVEAL_DELAY_MS = 200;
+/** Debounce applied to search-as-you-type. */
+const SEARCH_DEBOUNCE_MS = 150;
 
 interface SearchReplacePanelProps {
   editorRef: React.RefObject<editor.IStandaloneCodeEditor | null>;
@@ -108,7 +105,7 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
   // Focus search input when panel opens
   useEffect(() => {
     if (open && searchInputRef.current) {
-      setTimeout(() => searchInputRef.current?.focus(), 50);
+      setTimeout(() => searchInputRef.current?.focus(), FOCUS_DELAY_MS);
     }
     if (!open) {
       clearDecorations();
@@ -155,71 +152,33 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
     const model = ed.getModel();
     if (!model) return;
 
-    let searchRegex: RegExp;
-    try {
-      if (regex) {
-        searchRegex = new RegExp(searchText, caseSensitive ? 'g' : 'gi');
-      } else {
-        const escaped = searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const pattern = wholeWord ? `\\b${escaped}\\b` : escaped;
-        searchRegex = new RegExp(pattern, caseSensitive ? 'g' : 'gi');
-      }
-    } catch {
-      // Invalid regex
+    const searchRegex = buildSearchRegex(searchText, { caseSensitive, wholeWord, regex });
+    if (!searchRegex) {
       clearDecorations();
       setMatches([]);
       setCurrentMatchIndex(-1);
       return;
     }
 
-    const text = model.getValue();
-    const foundMatches: MatchInfo[] = [];
-    let match: RegExpExecArray | null;
-
-    while ((match = searchRegex.exec(text)) !== null) {
-      if (match[0].length === 0) {
-        searchRegex.lastIndex++;
-        continue;
-      }
-      const startPos = model.getPositionAt(match.index);
-      const endPos = model.getPositionAt(match.index + match[0].length);
-      const lineContent = model.getLineContent(startPos.lineNumber);
-
-      foundMatches.push({
-        range: {
-          startLineNumber: startPos.lineNumber,
-          startColumn: startPos.column,
-          endLineNumber: endPos.lineNumber,
-          endColumn: endPos.column,
-        },
-        text: match[0],
-        lineContent,
-      });
-    }
+    const foundMatches: MatchInfo[] = iterateMatches(model.getValue(), searchRegex).map(
+      ({ index, text }) => {
+        const startPos = model.getPositionAt(index);
+        const endPos = model.getPositionAt(index + text.length);
+        return {
+          range: {
+            startLineNumber: startPos.lineNumber,
+            startColumn: startPos.column,
+            endLineNumber: endPos.lineNumber,
+            endColumn: endPos.column,
+          },
+          text,
+          lineContent: model.getLineContent(startPos.lineNumber),
+        };
+      },
+    );
 
     setMatches(foundMatches);
-
-    // Try to keep current match near cursor position
-    if (foundMatches.length > 0) {
-      const cursorPos = ed.getPosition();
-      let bestIndex = 0;
-      if (cursorPos) {
-        for (let i = 0; i < foundMatches.length; i++) {
-          const r = foundMatches[i].range;
-          if (
-            r.startLineNumber > cursorPos.lineNumber ||
-            (r.startLineNumber === cursorPos.lineNumber && r.startColumn >= cursorPos.column)
-          ) {
-            bestIndex = i;
-            break;
-          }
-          bestIndex = i;
-        }
-      }
-      setCurrentMatchIndex(bestIndex);
-    } else {
-      setCurrentMatchIndex(-1);
-    }
+    setCurrentMatchIndex(pickNearestMatchIndex(foundMatches, ed.getPosition()));
   }, [editorRef, searchText, caseSensitive, wholeWord, regex, clearDecorations]);
 
   // Cross-tab search
@@ -230,53 +189,14 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
       return;
     }
 
-    let searchRegex: RegExp;
-    try {
-      if (regex) {
-        searchRegex = new RegExp(searchText, caseSensitive ? 'g' : 'gi');
-      } else {
-        const escaped = searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const pattern = wholeWord ? `\\b${escaped}\\b` : escaped;
-        searchRegex = new RegExp(pattern, caseSensitive ? 'g' : 'gi');
-      }
-    } catch {
+    const searchRegex = buildSearchRegex(searchText, { caseSensitive, wholeWord, regex });
+    if (!searchRegex) {
       setCrossTabMatches([]);
       setCurrentCrossTabIndex(-1);
       return;
     }
 
-    const allMatches: CrossTabMatchInfo[] = [];
-
-    for (const tab of tabs) {
-      const lines = tab.content.split(/\r?\n/);
-      // Reset regex for each tab
-      searchRegex.lastIndex = 0;
-
-      let match: RegExpExecArray | null;
-      const tabContent = tab.content;
-      searchRegex.lastIndex = 0;
-
-      while ((match = searchRegex.exec(tabContent)) !== null) {
-        if (match[0].length === 0) {
-          searchRegex.lastIndex++;
-          continue;
-        }
-        // Calculate line number and column
-        const beforeMatch = tabContent.substring(0, match.index);
-        const lineNumber = beforeMatch.split(/\r?\n/).length;
-        const lastNewline = beforeMatch.lastIndexOf('\n');
-        const column = match.index - lastNewline;
-
-        allMatches.push({
-          tabId: tab.id,
-          tabTitle: tab.title,
-          lineNumber,
-          column,
-          text: match[0],
-          lineContent: lines[lineNumber - 1] || '',
-        });
-      }
-    }
+    const allMatches: CrossTabMatchInfo[] = searchAcrossTabs(tabs, searchRegex);
 
     setCrossTabMatches(allMatches);
     if (allMatches.length > 0) {
@@ -324,7 +244,7 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
         setCrossTabMatches([]);
         setCurrentCrossTabIndex(-1);
       }
-    }, 150);
+    }, SEARCH_DEBOUNCE_MS);
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
@@ -392,7 +312,7 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
           ed.setPosition({ lineNumber: m.lineNumber, column: m.column });
           ed.focus();
         }
-      }, 200);
+      }, TAB_SWITCH_REVEAL_DELAY_MS);
     } else {
       // Same tab - jump directly
       const ed = editorRef.current;
@@ -755,76 +675,15 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
             overflowY: 'auto',
           }}
         >
-          {matches.map((m, i) => {
-            const col = m.range.startColumn - 1;
-            const matchLen = m.text.length;
-            const before = m.lineContent.substring(Math.max(0, col - 30), col);
-            const matched = m.lineContent.substring(col, col + matchLen);
-            const after = m.lineContent.substring(col + matchLen, col + matchLen + 40);
-
-            return (
-              <Box
-                key={`${m.range.startLineNumber}-${m.range.startColumn}-${i}`}
-                onClick={() => goToMatch(i)}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  px: 1,
-                  py: 0.25,
-                  cursor: 'pointer',
-                  fontSize: '12px',
-                  fontFamily: "'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace",
-                  backgroundColor:
-                    i === currentMatchIndex
-                      ? 'rgba(var(--color-primary-rgb, 3, 102, 214), 0.1)'
-                      : 'transparent',
-                  '&:hover': {
-                    backgroundColor: 'rgba(128, 128, 128, 0.1)',
-                  },
-                  borderBottom: '1px solid var(--color-border-light)',
-                  overflow: 'hidden',
-                }}
-              >
-                <Typography
-                  component="span"
-                  sx={{
-                    color: 'var(--color-text-secondary)',
-                    fontSize: '11px',
-                    minWidth: 40,
-                    textAlign: 'right',
-                    mr: 1,
-                    flexShrink: 0,
-                    userSelect: 'none',
-                  }}
-                >
-                  L{m.range.startLineNumber}
-                </Typography>
-                <Typography
-                  component="span"
-                  sx={{
-                    fontSize: '12px',
-                    color: 'var(--color-text)',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {before}
-                  <span
-                    style={{
-                      backgroundColor: 'var(--color-search-highlight)',
-                      color: 'var(--color-search-highlight-text)',
-                      borderRadius: '2px',
-                      padding: '0 1px',
-                    }}
-                  >
-                    {matched}
-                  </span>
-                  {after}
-                </Typography>
-              </Box>
-            );
-          })}
+          {matches.map((m, i) => (
+            <SearchMatchRow
+              key={`${m.range.startLineNumber}-${m.range.startColumn}-${i}`}
+              lineNumber={m.range.startLineNumber}
+              snippet={snippetParts(m.lineContent, m.range.startColumn - 1, m.text.length)}
+              active={i === currentMatchIndex}
+              onClick={() => goToMatch(i)}
+            />
+          ))}
         </Box>
       )}
 
@@ -886,77 +745,16 @@ const SearchReplacePanel: React.FC<SearchReplacePanelProps> = ({
                   </Typography>
                 </Box>
                 {/* Matches in this tab */}
-                {group.matches.map(({ match: m, globalIndex }) => {
-                  const col = m.column - 1;
-                  const matchLen = m.text.length;
-                  const before = m.lineContent.substring(Math.max(0, col - 30), col);
-                  const matched = m.lineContent.substring(col, col + matchLen);
-                  const after = m.lineContent.substring(col + matchLen, col + matchLen + 40);
-
-                  return (
-                    <Box
-                      key={`${m.tabId}-${m.lineNumber}-${m.column}-${globalIndex}`}
-                      onClick={() => goToCrossTabMatch(globalIndex)}
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        px: 1,
-                        pl: 2,
-                        py: 0.25,
-                        cursor: 'pointer',
-                        fontSize: '12px',
-                        fontFamily: "'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace",
-                        backgroundColor:
-                          globalIndex === currentCrossTabIndex
-                            ? 'rgba(var(--color-primary-rgb, 3, 102, 214), 0.1)'
-                            : 'transparent',
-                        '&:hover': {
-                          backgroundColor: 'rgba(128, 128, 128, 0.1)',
-                        },
-                        borderBottom: '1px solid var(--color-border-light)',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      <Typography
-                        component="span"
-                        sx={{
-                          color: 'var(--color-text-secondary)',
-                          fontSize: '11px',
-                          minWidth: 40,
-                          textAlign: 'right',
-                          mr: 1,
-                          flexShrink: 0,
-                          userSelect: 'none',
-                        }}
-                      >
-                        L{m.lineNumber}
-                      </Typography>
-                      <Typography
-                        component="span"
-                        sx={{
-                          fontSize: '12px',
-                          color: 'var(--color-text)',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {before}
-                        <span
-                          style={{
-                            backgroundColor: 'var(--color-search-highlight)',
-                            color: 'var(--color-search-highlight-text)',
-                            borderRadius: '2px',
-                            padding: '0 1px',
-                          }}
-                        >
-                          {matched}
-                        </span>
-                        {after}
-                      </Typography>
-                    </Box>
-                  );
-                })}
+                {group.matches.map(({ match: m, globalIndex }) => (
+                  <SearchMatchRow
+                    key={`${m.tabId}-${m.lineNumber}-${m.column}-${globalIndex}`}
+                    lineNumber={m.lineNumber}
+                    snippet={snippetParts(m.lineContent, m.column - 1, m.text.length)}
+                    active={globalIndex === currentCrossTabIndex}
+                    indented
+                    onClick={() => goToCrossTabMatch(globalIndex)}
+                  />
+                ))}
               </Box>
             ));
           })()}

--- a/src/components/search/SearchMatchRow.tsx
+++ b/src/components/search/SearchMatchRow.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import type { SnippetParts } from '../../utils/searchMatches';
+
+interface SearchMatchRowProps {
+  lineNumber: number;
+  snippet: SnippetParts;
+  active: boolean;
+  /** Adds extra left padding for matches nested under a cross-tab group header. */
+  indented?: boolean;
+  onClick: () => void;
+}
+
+/**
+ * A single clickable row in the search result list. Renders the line number and
+ * the match context with the matched text highlighted. Shared by the single-tab
+ * and cross-tab result lists so their markup stays in sync.
+ */
+const SearchMatchRow: React.FC<SearchMatchRowProps> = ({
+  lineNumber,
+  snippet,
+  active,
+  indented = false,
+  onClick,
+}) => (
+  <Box
+    onClick={onClick}
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      px: 1,
+      ...(indented ? { pl: 2 } : {}),
+      py: 0.25,
+      cursor: 'pointer',
+      fontSize: '12px',
+      fontFamily: "'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace",
+      backgroundColor: active
+        ? 'rgba(var(--color-primary-rgb, 3, 102, 214), 0.1)'
+        : 'transparent',
+      '&:hover': {
+        backgroundColor: 'rgba(128, 128, 128, 0.1)',
+      },
+      borderBottom: '1px solid var(--color-border-light)',
+      overflow: 'hidden',
+    }}
+  >
+    <Typography
+      component="span"
+      sx={{
+        color: 'var(--color-text-secondary)',
+        fontSize: '11px',
+        minWidth: 40,
+        textAlign: 'right',
+        mr: 1,
+        flexShrink: 0,
+        userSelect: 'none',
+      }}
+    >
+      L{lineNumber}
+    </Typography>
+    <Typography
+      component="span"
+      sx={{
+        fontSize: '12px',
+        color: 'var(--color-text)',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {snippet.before}
+      <span
+        style={{
+          backgroundColor: 'var(--color-search-highlight)',
+          color: 'var(--color-search-highlight-text)',
+          borderRadius: '2px',
+          padding: '0 1px',
+        }}
+      >
+        {snippet.matched}
+      </span>
+      {snippet.after}
+    </Typography>
+  </Box>
+);
+
+export default SearchMatchRow;

--- a/src/hooks/useDesktopEventListeners.ts
+++ b/src/hooks/useDesktopEventListeners.ts
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState } from 'react';
+import { isImageFilePath } from '../utils/imageInsertion';
+import { isSupportedDocumentFile } from '../utils/fileDropFilters';
+
+type SnackbarState = { open: boolean; message: string; severity: 'success' | 'error' | 'warning' };
+
+/** Handlers the desktop event listeners invoke, always read via a live ref. */
+export interface DesktopEventHandlers {
+  handleNewTab: () => void;
+  handleSaveFile: () => void;
+  handleSaveFileAs: () => void;
+  handleSaveWithVariables: () => void;
+  handleHelpOpen: () => void;
+  openFile: (filePath?: string) => Promise<string>;
+  requestEditorFocus: () => void;
+  setIsDragOver: (value: boolean) => void;
+  setSnackbar: (snackbar: SnackbarState) => void;
+  t: (key: string) => string;
+}
+
+/** Suppress duplicate native menu events fired in quick succession. */
+const MENU_DEBOUNCE_MS = 100;
+/** Suppress a repeat open-file event for the same path (macOS re-fires on drop). */
+const FILE_OPEN_DEBOUNCE_MS = 2000;
+
+/**
+ * Register the Tauri menu, file-association, and drag-drop listeners once, and
+ * report when they are all wired up. Handlers are read through a ref so the
+ * listeners always call the latest closures without re-registering.
+ *
+ * @returns whether every listener has finished registering.
+ */
+export function useDesktopEventListeners(handlers: DesktopEventHandlers): boolean {
+  const [listenersReady, setListenersReady] = useState(false);
+
+  // Always hold the latest handlers, avoiding stale closures in event listeners.
+  const handlersRef = useRef(handlers);
+  useEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    let unlistenMenu: (() => void) | undefined;
+    let unlistenNewFile: (() => void) | undefined;
+    let unlistenOpenFile: (() => void) | undefined;
+    let unlistenSaveAs: (() => void) | undefined;
+    let unlistenSaveWithVariables: (() => void) | undefined;
+    let unlistenHelp: (() => void) | undefined;
+    let unlistenFileOpen: (() => void) | undefined;
+    let unlistenDragDrop: (() => void) | undefined;
+
+    const setupMenuListeners = async () => {
+      const { listen } = await import('@tauri-apps/api/event');
+
+      // If effect was cleaned up during the async import, don't register listeners
+      if (cancelled) return;
+
+      // Shared debounce state for menu events (attached to window to survive re-renders)
+      const globalDebounce = (window as unknown as {
+        lastMenuEventTime?: number;
+      });
+
+      if (!globalDebounce.lastMenuEventTime) {
+        globalDebounce.lastMenuEventTime = 0;
+      }
+
+      // Returns true if the event should be suppressed (within debounce window)
+      const isMenuDebounced = (): boolean => {
+        const now = Date.now();
+        if (now - globalDebounce.lastMenuEventTime! < MENU_DEBOUNCE_MS) {
+          return true;
+        }
+        globalDebounce.lastMenuEventTime = now;
+        return false;
+      };
+
+      unlistenMenu = await listen('menu-save', () => {
+        if (!isMenuDebounced()) handlersRef.current.handleSaveFile();
+      });
+
+      unlistenNewFile = await listen('menu-new-file', () => {
+        if (!isMenuDebounced()) handlersRef.current.handleNewTab();
+      });
+
+      unlistenOpenFile = await listen('menu-open-file', async () => {
+        if (isMenuDebounced()) return;
+        try {
+          await handlersRef.current.openFile();
+        } catch (error) {
+          console.error('Failed to open file from menu:', error);
+        }
+      });
+
+      unlistenSaveAs = await listen('menu-save-as', () => {
+        if (!isMenuDebounced()) handlersRef.current.handleSaveFileAs();
+      });
+
+      unlistenSaveWithVariables = await listen('menu-save-with-variables', () => {
+        if (!isMenuDebounced()) handlersRef.current.handleSaveWithVariables();
+      });
+
+      unlistenHelp = await listen('menu-help', () => {
+        if (!isMenuDebounced()) handlersRef.current.handleHelpOpen();
+      });
+
+      // File association event listener with debounce
+      const fileOpenDebounce = (window as unknown as {
+        lastFileOpenTime?: number;
+        lastFilePath?: string;
+      });
+
+      if (!fileOpenDebounce.lastFileOpenTime) {
+        fileOpenDebounce.lastFileOpenTime = 0;
+      }
+      if (!fileOpenDebounce.lastFilePath) {
+        fileOpenDebounce.lastFilePath = '';
+      }
+
+      unlistenFileOpen = await listen('open-file', async (event: { payload: { file_path: string } }) => {
+        const now = Date.now();
+        const timeDiff = now - fileOpenDebounce.lastFileOpenTime!;
+        const currentFilePath = event.payload.file_path;
+        const isSameFile = currentFilePath === fileOpenDebounce.lastFilePath;
+
+        // Debounce: same file within time limit
+        if (isSameFile && timeDiff < FILE_OPEN_DEBOUNCE_MS) {
+          return;
+        }
+        fileOpenDebounce.lastFileOpenTime = now;
+        fileOpenDebounce.lastFilePath = currentFilePath;
+        await handlersRef.current.openFile(currentFilePath);
+        handlersRef.current.requestEditorFocus();
+      });
+
+      // Drag and drop event listener (uses Tauri API to get file paths)
+      const { getCurrentWebview } = await import('@tauri-apps/api/webview');
+      if (cancelled) return;
+
+      unlistenDragDrop = await getCurrentWebview().onDragDropEvent(async (event) => {
+        if (event.payload.type === 'enter') {
+          const hasSupported = event.payload.paths.some(isSupportedDocumentFile);
+          if (hasSupported) {
+            handlersRef.current.setIsDragOver(true);
+          }
+        } else if (event.payload.type === 'leave') {
+          handlersRef.current.setIsDragOver(false);
+        } else if (event.payload.type === 'drop') {
+          handlersRef.current.setIsDragOver(false);
+          const supportedPaths = event.payload.paths.filter(isSupportedDocumentFile);
+          if (supportedPaths.length === 0) {
+            // Image drops are handled by the editor's own drag-drop listener
+            // (inserted as Markdown links), so don't treat them as an error here.
+            const hasImage = event.payload.paths.some(isImageFilePath);
+            if (!hasImage) {
+              handlersRef.current.setSnackbar({
+                open: true,
+                message: handlersRef.current.t('fileOperations.noMarkdownFiles'),
+                severity: 'error',
+              });
+            }
+            return;
+          }
+
+          // Mark in fileOpenDebounce so the subsequent RunEvent::Opened
+          // (which macOS also fires for dropped files) is suppressed
+          fileOpenDebounce.lastFileOpenTime = Date.now();
+          fileOpenDebounce.lastFilePath = supportedPaths[0];
+
+          try {
+            await handlersRef.current.openFile(supportedPaths[0]);
+            handlersRef.current.requestEditorFocus();
+          } catch {
+            handlersRef.current.setSnackbar({
+              open: true,
+              message: handlersRef.current.t('fileOperations.fileLoadFailed'),
+              severity: 'error',
+            });
+          }
+        }
+      });
+
+      // Signal that all listeners are registered
+      setListenersReady(true);
+    };
+
+    setupMenuListeners();
+
+    return () => {
+      cancelled = true;
+      if (unlistenMenu) unlistenMenu();
+      if (unlistenNewFile) unlistenNewFile();
+      if (unlistenOpenFile) unlistenOpenFile();
+      if (unlistenSaveAs) unlistenSaveAs();
+      if (unlistenSaveWithVariables) unlistenSaveWithVariables();
+      if (unlistenHelp) unlistenHelp();
+      if (unlistenFileOpen) unlistenFileOpen();
+      if (unlistenDragDrop) unlistenDragDrop();
+    };
+  }, []); // Empty dependency array to run only once
+
+  return listenersReady;
+}

--- a/src/utils/__tests__/editingContext.test.ts
+++ b/src/utils/__tests__/editingContext.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { computeEditingContext } from '../editingContext';
+
+const TABLE = ['| a | b |', '| --- | --- |', '| 1 | 2 |'];
+
+describe('computeEditingContext', () => {
+  it('marks a plain paragraph as neither table row nor list item', () => {
+    expect(computeEditingContext(['just some text'], 1)).toEqual({
+      inTableRow: false,
+      inListItem: false,
+    });
+  });
+
+  it('detects a list item line', () => {
+    expect(computeEditingContext(['- item'], 1)).toEqual({
+      inTableRow: false,
+      inListItem: true,
+    });
+  });
+
+  it('detects an ordered list item line', () => {
+    expect(computeEditingContext(['1. first'], 1)).toEqual({
+      inTableRow: false,
+      inListItem: true,
+    });
+  });
+
+  it('treats a table header/body row as a table row', () => {
+    expect(computeEditingContext(TABLE, 1)).toEqual({ inTableRow: true, inListItem: false });
+    expect(computeEditingContext(TABLE, 3)).toEqual({ inTableRow: true, inListItem: false });
+  });
+
+  it('does not treat the table separator line as an editable row', () => {
+    expect(computeEditingContext(TABLE, 2)).toEqual({ inTableRow: false, inListItem: false });
+  });
+
+  it('returns all-false for an out-of-range line', () => {
+    expect(computeEditingContext(['x'], 99)).toEqual({ inTableRow: false, inListItem: false });
+  });
+});

--- a/src/utils/__tests__/editorStatus.test.ts
+++ b/src/utils/__tests__/editorStatus.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { computeEditorStatus } from '../editorStatus';
+
+describe('computeEditorStatus', () => {
+  it('reports cursor position and total counts with no selection', () => {
+    expect(computeEditorStatus('hello world', '', { lineNumber: 3, column: 5 })).toEqual({
+      line: 3,
+      column: 5,
+      totalCharacters: 11,
+      selectedCharacters: 0,
+      totalWords: 2,
+      selectedWords: 0,
+    });
+  });
+
+  it('counts characters and words in the selection', () => {
+    const status = computeEditorStatus('one two three', 'two three', { lineNumber: 1, column: 1 });
+    expect(status.selectedCharacters).toBe(9);
+    expect(status.selectedWords).toBe(2);
+    expect(status.totalWords).toBe(3);
+  });
+
+  it('counts CJK characters per-character like the status bar does', () => {
+    const status = computeEditorStatus('日本語', '', { lineNumber: 1, column: 1 });
+    expect(status.totalCharacters).toBe(3);
+    expect(status.totalWords).toBe(3);
+  });
+});

--- a/src/utils/__tests__/fileDropFilters.test.ts
+++ b/src/utils/__tests__/fileDropFilters.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isSupportedDocumentFile } from '../fileDropFilters';
+
+describe('isSupportedDocumentFile', () => {
+  it('accepts markdown and text extensions', () => {
+    expect(isSupportedDocumentFile('/a/b/note.md')).toBe(true);
+    expect(isSupportedDocumentFile('/a/b/note.markdown')).toBe(true);
+    expect(isSupportedDocumentFile('/a/b/note.txt')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isSupportedDocumentFile('README.MD')).toBe(true);
+    expect(isSupportedDocumentFile('Notes.TXT')).toBe(true);
+  });
+
+  it('rejects other file types', () => {
+    expect(isSupportedDocumentFile('/a/b/image.png')).toBe(false);
+    expect(isSupportedDocumentFile('/a/b/doc.pdf')).toBe(false);
+    expect(isSupportedDocumentFile('/a/b/noext')).toBe(false);
+  });
+});

--- a/src/utils/__tests__/pasteClassifier.test.ts
+++ b/src/utils/__tests__/pasteClassifier.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { classifyPaste } from '../pasteClassifier';
+
+describe('classifyPaste', () => {
+  it('classifies plain text with no delimiters as plain', () => {
+    expect(classifyPaste('', 'hello world')).toEqual({ kind: 'plain' });
+  });
+
+  it('converts an HTML table to a Markdown table', () => {
+    const html = '<table><tr><td>a</td><td>b</td></tr><tr><td>1</td><td>2</td></tr></table>';
+    const result = classifyPaste(html, 'a b');
+    expect(result.kind).toBe('table');
+    if (result.kind === 'table') {
+      expect(result.markdownTable).toContain('|');
+    }
+  });
+
+  it('converts TSV plain text to a Markdown table', () => {
+    const tsv = 'a\tb\n1\t2';
+    const result = classifyPaste('', tsv);
+    expect(result.kind).toBe('table');
+    if (result.kind === 'table') {
+      expect(result.markdownTable).toContain('|');
+    }
+  });
+
+  it('falls back to plain for HTML without a table element', () => {
+    expect(classifyPaste('<p>hello</p>', 'hello')).toEqual({ kind: 'plain' });
+  });
+
+  it('prefers HTML table conversion over TSV when both are present', () => {
+    const html = '<table><tr><td>x</td><td>y</td></tr><tr><td>1</td><td>2</td></tr></table>';
+    const result = classifyPaste(html, 'ignored\ttext');
+    expect(result.kind).toBe('table');
+  });
+});

--- a/src/utils/__tests__/searchMatches.test.ts
+++ b/src/utils/__tests__/searchMatches.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSearchRegex,
+  iterateMatches,
+  searchAcrossTabs,
+  pickNearestMatchIndex,
+  snippetParts,
+  SNIPPET_CONTEXT_BEFORE,
+  SNIPPET_CONTEXT_AFTER,
+  type MatchInfo,
+} from '../searchMatches';
+import type { Tab } from '../../types/tab';
+
+const makeTab = (id: string, title: string, content: string): Tab =>
+  ({ id, title, content } as Tab);
+
+const makeMatch = (startLineNumber: number, startColumn: number): MatchInfo => ({
+  range: { startLineNumber, startColumn, endLineNumber: startLineNumber, endColumn: startColumn + 1 },
+  text: 'x',
+  lineContent: '',
+});
+
+describe('buildSearchRegex', () => {
+  it('returns null for empty query', () => {
+    expect(buildSearchRegex('', { caseSensitive: false, wholeWord: false, regex: false })).toBeNull();
+  });
+
+  it('escapes special characters in plain mode', () => {
+    const re = buildSearchRegex('a.b', { caseSensitive: true, wholeWord: false, regex: false })!;
+    expect(re.test('a.b')).toBe(true);
+    expect(re.test('axb')).toBe(false);
+  });
+
+  it('wraps with word boundaries when wholeWord is set', () => {
+    const re = buildSearchRegex('cat', { caseSensitive: false, wholeWord: true, regex: false })!;
+    expect('cat category'.match(re)).toHaveLength(1);
+  });
+
+  it('is case-insensitive unless caseSensitive is set', () => {
+    expect(buildSearchRegex('AB', { caseSensitive: false, wholeWord: false, regex: false })!.flags).toContain('i');
+    expect(buildSearchRegex('AB', { caseSensitive: true, wholeWord: false, regex: false })!.flags).not.toContain('i');
+  });
+
+  it('honors raw regex patterns in regex mode', () => {
+    const re = buildSearchRegex('a.b', { caseSensitive: true, wholeWord: false, regex: true })!;
+    expect(re.test('axb')).toBe(true);
+  });
+
+  it('returns null for an invalid regex pattern', () => {
+    expect(buildSearchRegex('(', { caseSensitive: false, wholeWord: false, regex: true })).toBeNull();
+  });
+});
+
+describe('iterateMatches', () => {
+  it('finds every non-overlapping match', () => {
+    const re = buildSearchRegex('a', { caseSensitive: false, wholeWord: false, regex: false })!;
+    expect(iterateMatches('banana', re)).toEqual([
+      { index: 1, text: 'a' },
+      { index: 3, text: 'a' },
+      { index: 5, text: 'a' },
+    ]);
+  });
+
+  it('skips zero-length matches without looping forever', () => {
+    const re = buildSearchRegex('a*', { caseSensitive: false, wholeWord: false, regex: true })!;
+    const result = iterateMatches('bab', re);
+    expect(result).toEqual([{ index: 1, text: 'a' }]);
+  });
+
+  it('resets lastIndex so the regex can be reused', () => {
+    const re = buildSearchRegex('a', { caseSensitive: false, wholeWord: false, regex: false })!;
+    iterateMatches('aa', re);
+    expect(iterateMatches('aa', re)).toHaveLength(2);
+  });
+});
+
+describe('searchAcrossTabs', () => {
+  it('computes 1-based line/column for each tab', () => {
+    const re = buildSearchRegex('foo', { caseSensitive: false, wholeWord: false, regex: false })!;
+    const tabs = [
+      makeTab('t1', 'One', 'foo\nbar foo'),
+      makeTab('t2', 'Two', 'nothing here'),
+    ];
+    const result = searchAcrossTabs(tabs, re);
+    expect(result).toEqual([
+      { tabId: 't1', tabTitle: 'One', lineNumber: 1, column: 1, text: 'foo', lineContent: 'foo' },
+      { tabId: 't1', tabTitle: 'One', lineNumber: 2, column: 5, text: 'foo', lineContent: 'bar foo' },
+    ]);
+  });
+
+  it('handles CRLF line endings', () => {
+    const re = buildSearchRegex('x', { caseSensitive: false, wholeWord: false, regex: false })!;
+    const result = searchAcrossTabs([makeTab('t', 'T', 'a\r\nx')], re);
+    expect(result[0].lineNumber).toBe(2);
+    expect(result[0].lineContent).toBe('x');
+  });
+});
+
+describe('pickNearestMatchIndex', () => {
+  it('returns -1 when there are no matches', () => {
+    expect(pickNearestMatchIndex([], { lineNumber: 1, column: 1 })).toBe(-1);
+  });
+
+  it('returns 0 when cursor is unknown', () => {
+    expect(pickNearestMatchIndex([makeMatch(5, 1)], null)).toBe(0);
+  });
+
+  it('returns the first match at or after the cursor', () => {
+    const matches = [makeMatch(1, 1), makeMatch(3, 1), makeMatch(5, 1)];
+    expect(pickNearestMatchIndex(matches, { lineNumber: 2, column: 1 })).toBe(1);
+    expect(pickNearestMatchIndex(matches, { lineNumber: 3, column: 1 })).toBe(1);
+  });
+
+  it('falls back to the last match when the cursor is past all matches', () => {
+    const matches = [makeMatch(1, 1), makeMatch(3, 1)];
+    expect(pickNearestMatchIndex(matches, { lineNumber: 9, column: 1 })).toBe(1);
+  });
+});
+
+describe('snippetParts', () => {
+  it('splits a line into before/matched/after', () => {
+    expect(snippetParts('hello world', 6, 5)).toEqual({
+      before: 'hello ',
+      matched: 'world',
+      after: '',
+    });
+  });
+
+  it('clamps the before-context to the configured width', () => {
+    const line = 'a'.repeat(100) + 'MATCH';
+    const parts = snippetParts(line, 100, 5);
+    expect(parts.before).toHaveLength(SNIPPET_CONTEXT_BEFORE);
+    expect(parts.matched).toBe('MATCH');
+  });
+
+  it('limits the after-context to the configured width', () => {
+    const line = 'MATCH' + 'b'.repeat(100);
+    const parts = snippetParts(line, 0, 5);
+    expect(parts.after).toHaveLength(SNIPPET_CONTEXT_AFTER);
+  });
+});

--- a/src/utils/editingContext.ts
+++ b/src/utils/editingContext.ts
@@ -1,0 +1,24 @@
+import { findTableBlock, isTableSeparatorLine } from './tableFormatter';
+import { parseListItem } from './listFormatter';
+
+/**
+ * Whether the cursor line should activate table-row or list-item smart editing.
+ * The two are mutually exclusive so Enter/Tab dispatch to a single handler.
+ */
+export interface EditingContext {
+  inTableRow: boolean;
+  inListItem: boolean;
+}
+
+/**
+ * Decide the smart-editing context for a cursor line, given the full document
+ * lines and the 1-based cursor line number. A separator line inside a table is
+ * not treated as an editable row, and a table row is never a list item.
+ */
+export function computeEditingContext(lines: string[], lineNumber: number): EditingContext {
+  const lineContent = lines[lineNumber - 1] ?? '';
+  const block = findTableBlock(lines, lineNumber);
+  const inTableRow = !!block && !isTableSeparatorLine(lineContent);
+  const inListItem = !inTableRow && parseListItem(lineContent) !== null;
+  return { inTableRow, inListItem };
+}

--- a/src/utils/editorStatus.ts
+++ b/src/utils/editorStatus.ts
@@ -1,0 +1,30 @@
+import { countWords } from './wordCount';
+
+/** Cursor and word/character counts shown in the status bar. */
+export interface EditorStatus {
+  line: number;
+  column: number;
+  totalCharacters: number;
+  selectedCharacters: number;
+  totalWords: number;
+  selectedWords: number;
+}
+
+/**
+ * Compute the status-bar figures from the full document text, the selected text
+ * (empty string when nothing is selected), and the 1-based cursor position.
+ */
+export function computeEditorStatus(
+  fullText: string,
+  selectedText: string,
+  position: { lineNumber: number; column: number },
+): EditorStatus {
+  return {
+    line: position.lineNumber,
+    column: position.column,
+    totalCharacters: fullText.length,
+    selectedCharacters: selectedText.length,
+    totalWords: countWords(fullText),
+    selectedWords: countWords(selectedText),
+  };
+}

--- a/src/utils/fileDropFilters.ts
+++ b/src/utils/fileDropFilters.ts
@@ -1,0 +1,8 @@
+/**
+ * Whether a dropped/opened path is a document Bokuchi can open directly
+ * (Markdown or plain text). Image drops are handled separately by the editor.
+ */
+export function isSupportedDocumentFile(path: string): boolean {
+  const lower = path.toLowerCase();
+  return lower.endsWith('.md') || lower.endsWith('.markdown') || lower.endsWith('.txt');
+}

--- a/src/utils/pasteClassifier.ts
+++ b/src/utils/pasteClassifier.ts
@@ -1,0 +1,32 @@
+import { htmlTableToMarkdown, validateMarkdownTable, convertTsvCsvToMarkdown } from './tableConverter';
+
+/**
+ * How a pasted payload should be inserted: either as a converted Markdown table
+ * or verbatim as plain text.
+ */
+export type PasteClassification =
+  | { kind: 'table'; markdownTable: string }
+  | { kind: 'plain' };
+
+/**
+ * Classify clipboard content for paste. An HTML `<table>` is converted first;
+ * otherwise TSV/CSV plain text (containing tabs or commas) is tried. If the
+ * conversion does not yield a valid Markdown table, the paste is plain text.
+ */
+export function classifyPaste(htmlData: string, plainText: string): PasteClassification {
+  let markdownTable: string;
+
+  if (htmlData && htmlData.includes('<table') && htmlData.includes('</table>')) {
+    markdownTable = htmlTableToMarkdown(htmlData);
+  } else if (plainText && (plainText.includes('\t') || plainText.includes(','))) {
+    markdownTable = convertTsvCsvToMarkdown(plainText);
+  } else {
+    return { kind: 'plain' };
+  }
+
+  if (!validateMarkdownTable(markdownTable)) {
+    return { kind: 'plain' };
+  }
+
+  return { kind: 'table', markdownTable };
+}

--- a/src/utils/registerEditorActions.ts
+++ b/src/utils/registerEditorActions.ts
@@ -1,0 +1,199 @@
+import type { editor, IDisposable } from 'monaco-editor';
+import type * as MonacoNs from 'monaco-editor';
+import { formatTableInEditor, handleTableEnter, handleTableTab } from './tableEditorActions';
+import { handleListEnter, handleListIndent } from './listEditorActions';
+import { computeEditingContext } from './editingContext';
+
+/** Callbacks the editor invokes to open the search/replace panel. */
+export interface SearchShortcutHandlers {
+  /** Ctrl/Cmd+F — open search in the current tab. */
+  openSearch: () => void;
+  /** Ctrl/Cmd+H — open search with the replace row expanded. */
+  openReplace: () => void;
+  /** Ctrl/Cmd+Shift+F — open search across all tabs. */
+  openSearchAllTabs: () => void;
+}
+
+/**
+ * Register search shortcuts, the Shift+Cmd/Ctrl+V no-op, and the smart
+ * table/list editing actions on a freshly mounted editor.
+ *
+ * The context keys `bokuchiInTableRow` / `bokuchiInListItem` gate the Enter/Tab
+ * overrides and are cleared during IME composition so Japanese conversion is
+ * never hijacked. Returns the disposables the caller must track so the listeners
+ * are torn down on the next mount/unmount.
+ */
+export function registerEditorActions(
+  ed: editor.IStandaloneCodeEditor,
+  monaco: typeof MonacoNs,
+  handlers: SearchShortcutHandlers,
+): IDisposable[] {
+  const disposables: IDisposable[] = [];
+
+  // --- Search / replace shortcuts ---
+  ed.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, handlers.openSearch);
+  ed.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyH, handlers.openReplace);
+  ed.addCommand(
+    monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyF,
+    handlers.openSearchAllTabs,
+  );
+
+  // Completely disable the default behavior of Shift + Cmd/Ctrl + V.
+  ed.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyV, () => {
+    // Do nothing (completely disable default "Paste as Plain Text")
+  });
+  // Disable with a more powerful method.
+  ed.addAction({
+    id: 'disable-shift-v',
+    label: 'Disable Shift+V',
+    keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyV],
+    run: () => {
+      // Do nothing
+    },
+  });
+
+  // --- Markdown table editing (format, Enter, Tab) ---
+
+  // Format the table block at the cursor.
+  ed.addAction({
+    id: 'format-markdown-table',
+    label: 'Format Markdown Table',
+    keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyL],
+    run: (editorInstance) => {
+      formatTableInEditor(editorInstance as editor.IStandaloneCodeEditor);
+    },
+  });
+
+  // Context keys gating Enter/Tab overrides. Cleared while an IME composition is
+  // active so Japanese conversion (Enter to confirm) and default Tab are never
+  // hijacked.
+  const inTableRowKey = ed.createContextKey<boolean>('bokuchiInTableRow', false);
+  const inListItemKey = ed.createContextKey<boolean>('bokuchiInListItem', false);
+  let isComposing = false;
+
+  const clearEditingContext = () => {
+    inTableRowKey.set(false);
+    inListItemKey.set(false);
+  };
+
+  const updateEditingContext = () => {
+    if (isComposing) {
+      clearEditingContext();
+      return;
+    }
+    const model = ed.getModel();
+    const pos = ed.getPosition();
+    if (!model || !pos) {
+      clearEditingContext();
+      return;
+    }
+    const { inTableRow, inListItem } = computeEditingContext(model.getLinesContent(), pos.lineNumber);
+    inTableRowKey.set(inTableRow);
+    inListItemKey.set(inListItem);
+  };
+
+  disposables.push(
+    ed.onDidCompositionStart(() => {
+      isComposing = true;
+      clearEditingContext();
+    }),
+  );
+  disposables.push(
+    ed.onDidCompositionEnd(() => {
+      isComposing = false;
+      updateEditingContext();
+    }),
+  );
+  disposables.push(ed.onDidChangeCursorPosition(updateEditingContext));
+  disposables.push(ed.onDidChangeModelContent(updateEditingContext));
+  updateEditingContext();
+
+  // Enter adds a new row / exits the table when on an empty row. If the handler
+  // declines (e.g. an active selection), fall back to a normal newline so the
+  // key is never swallowed.
+  ed.addAction({
+    id: 'table-enter-new-row',
+    label: 'Table: New Row',
+    keybindings: [monaco.KeyCode.Enter],
+    precondition: 'bokuchiInTableRow',
+    run: (editorInstance) => {
+      const e = editorInstance as editor.IStandaloneCodeEditor;
+      if (!handleTableEnter(e)) {
+        e.trigger('keyboard', 'type', { text: '\n' });
+      }
+    },
+  });
+
+  // Tab / Shift+Tab move between cells; fall back to default indent/outdent when
+  // the handler declines.
+  ed.addAction({
+    id: 'table-next-cell',
+    label: 'Table: Next Cell',
+    keybindings: [monaco.KeyCode.Tab],
+    precondition: 'bokuchiInTableRow',
+    run: (editorInstance) => {
+      const e = editorInstance as editor.IStandaloneCodeEditor;
+      if (!handleTableTab(e, false)) {
+        e.trigger('keyboard', 'tab', null);
+      }
+    },
+  });
+  ed.addAction({
+    id: 'table-prev-cell',
+    label: 'Table: Previous Cell',
+    keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Tab],
+    precondition: 'bokuchiInTableRow',
+    run: (editorInstance) => {
+      const e = editorInstance as editor.IStandaloneCodeEditor;
+      if (!handleTableTab(e, true)) {
+        e.trigger('keyboard', 'outdent', null);
+      }
+    },
+  });
+
+  // --- Smart Markdown list editing (Enter continuation, Tab indent) ---
+
+  // Enter continues the list (or ends it on an empty item). Fall back to a
+  // normal newline when the handler declines (e.g. active selection).
+  ed.addAction({
+    id: 'list-enter-continue',
+    label: 'List: Continue Item',
+    keybindings: [monaco.KeyCode.Enter],
+    precondition: 'bokuchiInListItem',
+    run: (editorInstance) => {
+      const e = editorInstance as editor.IStandaloneCodeEditor;
+      if (!handleListEnter(e)) {
+        e.trigger('keyboard', 'type', { text: '\n' });
+      }
+    },
+  });
+
+  // Tab / Shift+Tab indent or outdent the list item; fall back to the default
+  // indent/outdent when the handler declines.
+  ed.addAction({
+    id: 'list-indent',
+    label: 'List: Indent Item',
+    keybindings: [monaco.KeyCode.Tab],
+    precondition: 'bokuchiInListItem',
+    run: (editorInstance) => {
+      const e = editorInstance as editor.IStandaloneCodeEditor;
+      if (!handleListIndent(e, false)) {
+        e.trigger('keyboard', 'tab', null);
+      }
+    },
+  });
+  ed.addAction({
+    id: 'list-outdent',
+    label: 'List: Outdent Item',
+    keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Tab],
+    precondition: 'bokuchiInListItem',
+    run: (editorInstance) => {
+      const e = editorInstance as editor.IStandaloneCodeEditor;
+      if (!handleListIndent(e, true)) {
+        e.trigger('keyboard', 'outdent', null);
+      }
+    },
+  });
+
+  return disposables;
+}

--- a/src/utils/searchMatches.ts
+++ b/src/utils/searchMatches.ts
@@ -1,0 +1,155 @@
+import type { Tab } from '../types/tab';
+
+/** A single match located inside the active editor, with Monaco 1-based range. */
+export interface MatchInfo {
+  range: {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+  };
+  text: string;
+  lineContent: string;
+}
+
+/** A single match located in one of the open tabs (cross-tab search). */
+export interface CrossTabMatchInfo {
+  tabId: string;
+  tabTitle: string;
+  lineNumber: number;
+  column: number;
+  text: string;
+  lineContent: string;
+}
+
+/** Toggleable search modifiers shared by single-editor and cross-tab search. */
+export interface SearchOptions {
+  caseSensitive: boolean;
+  wholeWord: boolean;
+  regex: boolean;
+}
+
+/** Characters of context rendered before a match in the result list. */
+export const SNIPPET_CONTEXT_BEFORE = 30;
+/** Characters of context rendered after a match in the result list. */
+export const SNIPPET_CONTEXT_AFTER = 40;
+
+/**
+ * Build the search RegExp for the given query and options.
+ * Returns null when the query is empty or the pattern is an invalid regex,
+ * so callers can uniformly treat "no usable pattern" as "no matches".
+ */
+export function buildSearchRegex(searchText: string, options: SearchOptions): RegExp | null {
+  if (!searchText) return null;
+  const flags = options.caseSensitive ? 'g' : 'gi';
+  try {
+    if (options.regex) {
+      return new RegExp(searchText, flags);
+    }
+    const escaped = searchText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = options.wholeWord ? `\\b${escaped}\\b` : escaped;
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
+/** A raw match: byte offset into the source text plus the matched substring. */
+export interface RawMatch {
+  index: number;
+  text: string;
+}
+
+/**
+ * Iterate all non-empty matches of a global regex in the text.
+ * Skips zero-length matches (advancing lastIndex) to avoid infinite loops.
+ * Resets lastIndex up front so the regex can be reused across calls.
+ */
+export function iterateMatches(text: string, regex: RegExp): RawMatch[] {
+  const result: RawMatch[] = [];
+  regex.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    if (match[0].length === 0) {
+      regex.lastIndex++;
+      continue;
+    }
+    result.push({ index: match.index, text: match[0] });
+  }
+  return result;
+}
+
+/**
+ * Find matches across all tabs, deriving the 1-based line and column from the
+ * string offset of each match.
+ */
+export function searchAcrossTabs(tabs: Tab[], regex: RegExp): CrossTabMatchInfo[] {
+  const allMatches: CrossTabMatchInfo[] = [];
+  for (const tab of tabs) {
+    const lines = tab.content.split(/\r?\n/);
+    for (const { index, text } of iterateMatches(tab.content, regex)) {
+      const beforeMatch = tab.content.substring(0, index);
+      const lineNumber = beforeMatch.split(/\r?\n/).length;
+      const lastNewline = beforeMatch.lastIndexOf('\n');
+      const column = index - lastNewline;
+      allMatches.push({
+        tabId: tab.id,
+        tabTitle: tab.title,
+        lineNumber,
+        column,
+        text,
+        lineContent: lines[lineNumber - 1] || '',
+      });
+    }
+  }
+  return allMatches;
+}
+
+/**
+ * Pick the first match at or after the cursor, falling back to the last match
+ * when the cursor is past every match. Returns -1 when there are no matches
+ * and 0 when the cursor position is unknown.
+ */
+export function pickNearestMatchIndex(
+  matches: MatchInfo[],
+  cursor: { lineNumber: number; column: number } | null,
+): number {
+  if (matches.length === 0) return -1;
+  if (!cursor) return 0;
+  let bestIndex = 0;
+  for (let i = 0; i < matches.length; i++) {
+    const r = matches[i].range;
+    if (
+      r.startLineNumber > cursor.lineNumber ||
+      (r.startLineNumber === cursor.lineNumber && r.startColumn >= cursor.column)
+    ) {
+      return i;
+    }
+    bestIndex = i;
+  }
+  return bestIndex;
+}
+
+/** The three text segments used to render a match with its context. */
+export interface SnippetParts {
+  before: string;
+  matched: string;
+  after: string;
+}
+
+/**
+ * Split a line into before/matched/after segments around a match, using the
+ * shared context widths. `zeroBasedColumn` is the 0-based start of the match.
+ */
+export function snippetParts(
+  lineContent: string,
+  zeroBasedColumn: number,
+  matchLength: number,
+): SnippetParts {
+  const col = zeroBasedColumn;
+  return {
+    before: lineContent.substring(Math.max(0, col - SNIPPET_CONTEXT_BEFORE), col),
+    matched: lineContent.substring(col, col + matchLength),
+    after: lineContent.substring(col + matchLength, col + matchLength + SNIPPET_CONTEXT_AFTER),
+  };
+}


### PR DESCRIPTION
## Summary

Behavior-preserving refactor that splits three of the largest source files (Editor.tsx, SearchReplacePanel.tsx, App.tsx) by extracting their entangled logic into pure,
unit-testable modules and focused hooks/components. Also fixes a Linux-only Rust compile error in the PDF export path that was breaking CI.

## Changes

- SearchReplacePanel (969→767 lines): de-duplicated the identical regex builder and pulled match-finding, cross-tab search, nearest-match selection, and snippet rendering into
pure utils/searchMatches.ts; extracted the two near-identical result rows into a shared search/SearchMatchRow.tsx; replaced magic-number delays with named constants.
- Editor (1047→847 lines): extracted pure helpers computeEditingContext, classifyPaste, and computeEditorStatus, and moved ~190 lines of Monaco action/context-key wiring into
utils/registerEditorActions.ts.
- App (736→448 lines): moved the menu / file-association / drag-drop listener effect into hooks/useDesktopEventListeners.ts, extracted the pure isSupportedDocumentFile filter, and
split the Rin-mode controls and Konami unlock animation into RinControls.tsx and KonamiUnlockOverlay.tsx.
- PDF export (Rust): wrapped the GTK PrintSettings::set values in Some(...) (output-uri, output-file-format) to fix an E0308 type mismatch that only surfaces on the Linux (gtk)
build in CI.

## Tests

Added 35 unit tests covering the newly-extracted pure functions, with no changes to existing tests:
- searchMatches.test.ts — regex building, match iteration (incl. zero-length guard), cross-tab line/column derivation, nearest-match selection, snippet clamping.
- editingContext.test.ts — table-row / list-item / separator-line detection.
- pasteClassifier.test.ts — HTML-table vs TSV/CSV vs plain-text classification and validation fallback.
- editorStatus.test.ts — character/word counts including CJK per-character counting.
- fileDropFilters.test.ts — supported document extensions, case-insensitivity, rejection of other types.

Full suite green (1217 frontend tests), plus lint, type-check, and production build passing. The Rust fix is in a Linux-only #[cfg] path and can only be verified by CI.