### PR TITLE
Add GitHub issue templates and UI/UX auto-labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,82 @@
+name: 🐛 Bug Report
+description: Report a bug to help us improve Bokuchi
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        **Security issues must be reported via [Security Advisory](https://github.com/Bokuchi-Editor/bokuchi/security/advisories/new), not here.**
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where it happens
+      description: Which part of the app is affected?
+      options:
+        - Editor
+        - Preview
+        - Tabs
+        - Settings
+        - File operations
+        - Export
+        - Marp mode
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Open '...'
+        2. Click on '...'
+        3. Type '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - OS: (e.g. macOS 15.5, Windows 11)
+        - Bokuchi version: (e.g. 0.14.0)
+    validations:
+      required: true
+  - type: checkboxes
+    id: uiux
+    attributes:
+      label: UI/UX
+      options:
+        - label: This bug involves UI/UX (visual design, layout, usability)
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Logs
+      description: If applicable, add screenshots or logs to help explain the problem.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,53 @@
+name: ✨ Feature Request
+description: Suggest a new feature or improvement for Bokuchi
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest an improvement!
+        **Security issues must be reported via [Security Advisory](https://github.com/Bokuchi-Editor/bokuchi/security/advisories/new), not here.**
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief overview of your proposal.
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behavior
+      description: How does Bokuchi currently behave in this area?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why is this needed?
+      description: What problem does this solve? Why is it valuable?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: Describe concretely how it should work. UI mockups and use cases are welcome.
+    validations:
+      required: true
+  - type: checkboxes
+    id: uiux
+    attributes:
+      label: UI/UX
+      options:
+        - label: This request involves UI/UX (visual design, layout, usability)
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the request.

--- a/.github/ISSUE_TEMPLATE/3-other.yml
+++ b/.github/ISSUE_TEMPLATE/3-other.yml
@@ -1,0 +1,20 @@
+name: 📝 Other
+description: Questions, discussions, or anything that doesn't fit the other templates
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reaching out!
+        **Security issues must be reported via [Security Advisory](https://github.com/Bokuchi-Editor/bokuchi/security/advisories/new), not here.**
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe your question or topic.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any background or additional information.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Security Vulnerability
+    url: https://github.com/Bokuchi-Editor/bokuchi/security/advisories/new
+    about: Please report security vulnerabilities via GitHub Security Advisory. Do NOT open a public issue for security problems.

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,27 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-uiux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add UI/UX label when the checkbox is checked
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            // Matches the checked "UI/UX" checkbox rendered by the issue forms
+            if (/^\s*-\s*\[x\]\s+.*UI\/UX/im.test(body)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: ['UI/UX'],
+              });
+            }


### PR DESCRIPTION
## Summary

Adds GitHub Issue Forms so that new issues are created from one of four structured entry points: Bug Report, Feature Request, Other, or a link to GitHub Security Advisory for
vulnerability reports. Blank issues are disabled, and an accompanying workflow automatically applies the `UI/UX` label when the reporter checks the UI/UX checkbox.

## Changes

- Added a Bug Report form (`bug` label) with required fields for description, affected area (dropdown), steps to reproduce, expected/actual behavior, and environment, plus
optional screenshots/logs and context.
- Added a Feature Request form (`enhancement` label) with required fields for summary, current behavior, motivation, and expected behavior, plus optional alternatives and context.
- Added a generic "Other" form for questions and topics that don't fit the other templates.
- Added `config.yml` that disables blank issues and directs security vulnerability reports to GitHub Security Advisory via a contact link instead of a public issue.
- Added an `Issue Labeler` workflow that applies the `UI/UX` label when the UI/UX checkbox is checked in a newly opened issue.
- Every template header reminds reporters that security issues must go through Security Advisory, not public issues.

## Tests

No test changes.