### PR TITLE
Default export filename to the source document's name

### DIFF
--- a/src/api/__tests__/desktopApi.test.ts
+++ b/src/api/__tests__/desktopApi.test.ts
@@ -312,6 +312,23 @@ describe('desktopApi.saveHtmlFile', () => {
     expect(result).toEqual({ success: true, filePath: '/export.html' });
   });
 
+  it('defaults the save dialog to markdown-export.html', async () => {
+    vi.mocked(save).mockResolvedValue('/export.html');
+    vi.mocked(writeTextFile).mockResolvedValue(undefined);
+    await desktopApi.saveHtmlFile('<html></html>');
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: 'markdown-export.html' }),
+    );
+  });
+
+  // #442: the export dialog is pre-filled with the source document's name.
+  it('passes a custom default name to the save dialog', async () => {
+    vi.mocked(save).mockResolvedValue('/notes.html');
+    vi.mocked(writeTextFile).mockResolvedValue(undefined);
+    await desktopApi.saveHtmlFile('<html></html>', 'notes.html');
+    expect(save).toHaveBeenCalledWith(expect.objectContaining({ defaultPath: 'notes.html' }));
+  });
+
   it('returns error when cancelled', async () => {
     vi.mocked(save).mockResolvedValue(null);
     const result = await desktopApi.saveHtmlFile('<html></html>');

--- a/src/api/desktopApi.ts
+++ b/src/api/desktopApi.ts
@@ -259,11 +259,14 @@ export const desktopApi = {
   },
 
   // Save HTML file
-  async saveHtmlFile(htmlContent: string): Promise<SaveResponse> {
+  async saveHtmlFile(
+    htmlContent: string,
+    defaultName: string = 'markdown-export.html',
+  ): Promise<SaveResponse> {
     try {
 
       const selected = await save({
-        defaultPath: 'markdown-export.html',
+        defaultPath: defaultName,
         filters: [
           {
             name: 'HTML Files',

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -100,6 +100,7 @@ const MarkdownPreview: React.FC<PreviewProps> = ({ content, darkMode, theme, glo
     darkMode,
     theme,
     tableLayout: previewSettings.tableLayout,
+    filePath,
   });
 
   // Anchor for the export-format menu (HTML / PDF).

--- a/src/components/preview/useHtmlExport.ts
+++ b/src/components/preview/useHtmlExport.ts
@@ -6,6 +6,7 @@ import { renderCode, contentHasMermaid, processMermaidBlocks } from '../../utils
 import { buildExportHTML } from '../../utils/exportStyles';
 import { sanitizeUserHtml } from '../../utils/sanitizeHtml';
 import { fixCjkEmphasis, stripCjkEmphasisMarker } from '../../utils/cjkEmphasis';
+import { deriveExportFileName } from '../../utils/pathUtils';
 
 // A4 page geometry in inches (210×297mm). Margins are applied via the CSS
 // @page box (WebKit honours those for the page margin), so the native margin
@@ -20,6 +21,8 @@ interface UseHtmlExportParams {
   darkMode: boolean;
   theme?: string;
   tableLayout: TableLayoutMode;
+  /** Source document path; names the export after it in the save dialog (#442). */
+  filePath?: string;
 }
 
 interface UseHtmlExport {
@@ -37,6 +40,7 @@ export function useHtmlExport({
   darkMode,
   theme,
   tableLayout,
+  filePath,
 }: UseHtmlExportParams): UseHtmlExport {
   const [exportError, setExportError] = useState<string | null>(null);
 
@@ -89,7 +93,7 @@ export function useHtmlExport({
       const fullHTML = buildExportHTML(html, darkMode, theme, tableLayout, katexCss);
 
       // Select save location via file dialog
-      const result = await desktopApi.saveHtmlFile(fullHTML);
+      const result = await desktopApi.saveHtmlFile(fullHTML, deriveExportFileName(filePath, 'html'));
 
       if (!result.success) {
         setExportError(result.error || 'Failed to save HTML file');
@@ -110,7 +114,7 @@ export function useHtmlExport({
       });
       // Render + print to PDF natively (Rust side); the page is saved to the
       // location chosen in the file dialog.
-      const result = await desktopApi.exportPdfFile(fullHTML, A4_PAGE);
+      const result = await desktopApi.exportPdfFile(fullHTML, A4_PAGE, deriveExportFileName(filePath, 'pdf'));
       if (!result.success && result.error !== 'Save cancelled by user') {
         setExportError(result.error || 'Failed to export PDF file');
       }

--- a/src/utils/__tests__/pathUtils.test.ts
+++ b/src/utils/__tests__/pathUtils.test.ts
@@ -7,6 +7,7 @@ import {
   isMarkdownFile,
   getTabDisplayTitle,
   formatFilePathForDisplay,
+  deriveExportFileName,
 } from '../pathUtils';
 import * as platform from '../platform';
 import type { Tab } from '../../types/tab';
@@ -266,5 +267,56 @@ describe('getTabDisplayTitle', () => {
   it('T-PU-35: truncates long CJK first lines to 20 characters', () => {
     const tab = makeTab({ content: 'あ'.repeat(25) });
     expect(getTabDisplayTitle(tab)).toBe('あ'.repeat(20) + '…');
+  });
+});
+
+// #442: export dialogs default to the source document's name.
+describe('deriveExportFileName', () => {
+  // T-PU-36
+  it('T-PU-36: replaces .md with the target extension', () => {
+    expect(deriveExportFileName('/home/user/notes.md', 'pdf')).toBe('notes.pdf');
+    expect(deriveExportFileName('/home/user/notes.md', 'html')).toBe('notes.html');
+  });
+
+  // T-PU-37
+  it('T-PU-37: replaces .markdown with the target extension', () => {
+    expect(deriveExportFileName('/docs/guide.markdown', 'pdf')).toBe('guide.pdf');
+    expect(deriveExportFileName('/docs/guide.markdown', 'html')).toBe('guide.html');
+  });
+
+  // T-PU-38: only the trailing markdown extension is swapped; inner dots
+  // are part of the document name and must survive.
+  it('T-PU-38: keeps inner dots and swaps only the trailing extension', () => {
+    expect(deriveExportFileName('/docs/release.notes.v2.md', 'pdf')).toBe('release.notes.v2.pdf');
+  });
+
+  // T-PU-39
+  it('T-PU-39: preserves non-ASCII file names', () => {
+    expect(deriveExportFileName('/docs/議事録メモ.md', 'pdf')).toBe('議事録メモ.pdf');
+    expect(deriveExportFileName('/docs/議事録メモ.md', 'html')).toBe('議事録メモ.html');
+  });
+
+  // T-PU-40: unsaved documents keep the legacy fixed name.
+  it('T-PU-40: falls back to the fixed name when there is no file path', () => {
+    expect(deriveExportFileName(undefined, 'pdf')).toBe('markdown-export.pdf');
+    expect(deriveExportFileName(undefined, 'html')).toBe('markdown-export.html');
+  });
+
+  // T-PU-41: markdown extensions match case-insensitively (Windows/macOS
+  // file systems are case-insensitive, so README.MD is a markdown file).
+  it('T-PU-41: matches the markdown extension case-insensitively', () => {
+    expect(deriveExportFileName('/docs/README.MD', 'pdf')).toBe('README.pdf');
+    expect(deriveExportFileName('/docs/Guide.Markdown', 'html')).toBe('Guide.html');
+  });
+
+  // T-PU-42: a non-markdown extension is not swallowed — appending keeps
+  // the source name intact instead of guessing at its extension.
+  it('T-PU-42: appends the target extension to non-markdown file names', () => {
+    expect(deriveExportFileName('/docs/notes.txt', 'pdf')).toBe('notes.txt.pdf');
+  });
+
+  // T-PU-43
+  it('T-PU-43: handles Windows-style paths', () => {
+    expect(deriveExportFileName('C:\\Users\\docs\\notes.md', 'pdf')).toBe('notes.pdf');
   });
 });

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -60,6 +60,29 @@ export const isMarkdownFile = (fileName: string): boolean => {
   return lowerName.endsWith('.md') || lowerName.endsWith('.markdown');
 };
 
+const MARKDOWN_EXTENSION_PATTERN = /\.(md|markdown)$/i;
+
+/**
+ * Derive the default export file name from the source document's path (#442).
+ * A trailing markdown extension is swapped for the target one; any other
+ * extension is kept and the target extension appended, so the export still
+ * carries the source name. Unsaved documents fall back to the legacy fixed
+ * name so the dialog behaves exactly as before.
+ */
+export const deriveExportFileName = (
+  filePath: string | undefined,
+  targetExtension: 'html' | 'pdf',
+): string => {
+  if (!filePath) {
+    return `markdown-export.${targetExtension}`;
+  }
+  const fileName = extractFileNameFromPath(filePath);
+  if (MARKDOWN_EXTENSION_PATTERN.test(fileName)) {
+    return fileName.replace(MARKDOWN_EXTENSION_PATTERN, `.${targetExtension}`);
+  }
+  return `${fileName}.${targetExtension}`;
+};
+
 const UNTITLED_TAB_TITLE_MAX_LENGTH = 20;
 
 /**


### PR DESCRIPTION
## Summary

HTML and PDF export dialogs now pre-fill the filename based on the source
document instead of the fixed `markdown-export.*` name (#442). Unsaved
documents keep the previous fixed default.

## Changes

- Added `deriveExportFileName` utility that swaps a trailing `.md` /
  `.markdown` extension (case-insensitively) for the export target extension,
  appends the extension for non-markdown files, and preserves inner dots,
  non-ASCII names, and Windows-style paths.
- `desktopApi.saveHtmlFile` now accepts an optional default filename for the
  save dialog, falling back to `markdown-export.html`.
- The HTML/PDF export flow (`useHtmlExport`) derives the default name from the
  current tab's file path, which `Preview` now passes through.

## Tests

- Added `deriveExportFileName` unit tests (T-PU-36〜T-PU-43): markdown
  extension replacement, `.markdown` variant, inner dots, non-ASCII names,
  fallback for unsaved documents, case-insensitive matching, non-markdown
  extensions, and Windows paths.
- Added `desktopApi.saveHtmlFile` tests verifying the default and custom
  `defaultPath` passed to the save dialog.