### PR TITLE
fix(preview): Fixed a bug where the preview did not update when switc…

### DIFF
--- a/src/components/preview/useProcessedMarkdown.ts
+++ b/src/components/preview/useProcessedMarkdown.ts
@@ -163,6 +163,7 @@ export function useProcessedMarkdown({
       } else {
         setProcessedContent('');
         setHtmlContent('');
+        lastProcessedInputRef.current = '';
       }
     };
 


### PR DESCRIPTION
## Summary

Fix Preview going blank after adding and deleting a tab.

The `useProcessedMarkdown` hook caches processed input via `lastProcessedInputRef` to skip redundant re-processing (e.g. on auto-save). When a tab is closed, the hook sets `htmlContent` to `''` via the empty-content branch, but **does not reset the cache ref**. If the user then returns to the original tab — whose content matches the previously cached key — the early-return guard at line 82 fires and `setHtmlContent()` is never called, leaving the preview permanently blank.

Resetting `lastProcessedInputRef.current` to `''` in the empty-content branch ensures the cache is invalidated, so switching back to a previously-viewed document always triggers a full re-render.

## Related Issue

#508

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Other:

## How Has This Been Tested?

- `npm run lint` — passes
- `npm run type-check` — passes
- `npm run test:unit` — 1399/1399 tests pass
- Manual verification: open a document → add new tab → close new tab → confirm the original document's Preview is restored
- OS: macOS

## Screenshots (if UI change)

None (no visual change when the fix works correctly; the previously blank Preview now renders as expected).

## Checklist

- [x] This PR targets the `develop` branch (not `main`)
- [x] `npm run test:all` passes locally
- [x] `npm run lint` passes locally
- [ ] Documentation (README / docs) is updated if user-facing behavior changes
- [x] PR title and description are written in English