### PR TITLE
Fix lockfile registry URLs and harden CI supply chain (#512)

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Auto-merge PR
       if: steps.check.outputs.ready == 'true'
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           // 自動マージを有効化

--- a/.github/workflows/dependabot-test.yml
+++ b/.github/workflows/dependabot-test.yml
@@ -17,18 +17,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: "package-lock.json"
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master (toolchain via input)
         with:
+          toolchain: stable
           components: rustfmt, clippy
           targets: x86_64-unknown-linux-gnu
 
@@ -43,7 +44,7 @@ jobs:
             librsvg2-dev
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry
@@ -82,7 +83,7 @@ jobs:
 
       - name: Comment on PR
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -94,7 +95,7 @@ jobs:
 
       - name: Comment on PR (Success)
         if: success()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+
+# Diff-based supply-chain gate: flags known-vulnerable or malicious
+# dependencies introduced or updated by a pull request.
+# Complements security-audit.yml, which audits the full existing tree.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add UI/UX label when the checkbox is checked
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const body = context.payload.issue.body || '';

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -1,0 +1,65 @@
+name: Registry Check
+
+# Guards the supply chain of committed lockfiles:
+# every dependency must resolve to the official public registry.
+# Background: a local proxy registry can silently rewrite `resolved` URLs
+# on `npm install`, which breaks `npm ci` for everyone else
+# (issue #512, KNOWLEDGE.md B-12).
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  registry-check:
+    name: Lockfile registry check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Check package-lock.json resolved URLs
+        run: |
+          bad=$(grep '"resolved"' package-lock.json | grep -v '"resolved": "https://registry\.npmjs\.org/' || true)
+          if [ -n "$bad" ]; then
+            echo "::error file=package-lock.json::resolved URLs not pointing to registry.npmjs.org were found"
+            echo "$bad"
+            echo ""
+            echo "Fix: rewrite the offending URLs to https://registry.npmjs.org/ , or"
+            echo "regenerate the lockfile with: npm install --registry=https://registry.npmjs.org"
+            exit 1
+          fi
+          echo "OK: all resolved URLs point to registry.npmjs.org"
+
+      - name: Check Cargo.lock sources
+        run: |
+          bad=$(grep '^source = ' src-tauri/Cargo.lock | grep -v '^source = "registry+https://github.com/rust-lang/crates.io-index"' || true)
+          if [ -n "$bad" ]; then
+            echo "::error file=src-tauri/Cargo.lock::crate sources not pointing to crates.io were found"
+            echo "$bad" | sort -u
+            exit 1
+          fi
+          echo "OK: all crate sources point to crates.io"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      # Verifies registry signatures and provenance attestations of every
+      # installed package against the npm registry's public keys.
+      - name: Verify npm package signatures
+        run: npm audit signatures

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
@@ -30,8 +30,9 @@ jobs:
         run: npm ci
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master (toolchain via input)
         with:
+          toolchain: stable
           targets: x86_64-unknown-linux-gnu
 
       - name: Install system dependencies
@@ -55,7 +56,7 @@ jobs:
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
@@ -76,12 +77,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
@@ -90,8 +91,9 @@ jobs:
         run: npm ci
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master (toolchain via input)
         with:
+          toolchain: stable
           targets: aarch64-unknown-linux-gnu
 
       - name: Install system dependencies
@@ -114,7 +116,7 @@ jobs:
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install system dependencies
         run: |
@@ -23,14 +23,15 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master (toolchain via input)
         with:
+          toolchain: stable
           components: rustfmt, clippy
           targets: x86_64-unknown-linux-gnu
 
@@ -41,7 +42,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry
@@ -104,7 +105,7 @@ jobs:
 
       - name: Upload audit results
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: security-audit-results
           path: |

--- a/.github/workflows/tauri-update-monitor.yml
+++ b/.github/workflows/tauri-update-monitor.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
       with:
         toolchain: stable
         override: true
@@ -37,7 +37,7 @@ jobs:
 
     - name: Create issue if Tauri updated
       if: failure()
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           const title = 'Tauri Update Available - glib Security Fix Check';

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
           cache: "npm"
@@ -47,10 +47,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master (toolchain via input)
+        with:
+          toolchain: stable
 
       - name: Install system dependencies
         run: |
@@ -63,7 +65,7 @@ jobs:
             librsvg2-dev
 
       - name: Cache Cargo
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry

--- a/package-lock.json
+++ b/package-lock.json
@@ -6222,7 +6222,7 @@
     },
     "node_modules/speech-rule-engine": {
       "version": "4.0.7",
-      "resolved": "https://npm.flatt.tech/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
       "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6236,7 +6236,7 @@
     },
     "node_modules/speech-rule-engine/node_modules/commander": {
       "version": "9.2.0",
-      "resolved": "https://npm.flatt.tech/commander/-/commander-9.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
       "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "license": "MIT",
       "engines": {
@@ -6981,7 +6981,7 @@
     },
     "node_modules/xmldom-sre": {
       "version": "0.1.31",
-      "resolved": "https://npm.flatt.tech/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
       "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
       "license": "(LGPL-2.0 or MIT)",
       "engines": {


### PR DESCRIPTION
## Summary

Fixes issue #512: three entries in package-lock.json resolved to a private proxy registry instead of registry.npmjs.org, breaking npm ci for contributors on npm >= 12 (EALLOWREMOTE). 
This PR rewrites those URLs and adds CI guards so this class of issue is caught automatically instead of by users.

## Related Issue

- #512 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Other:

## How Has This Been Tested?

No test changes. 
The registry check was verified locally in both directions: it passes on the fixed lockfile and detects the three offending URLs in the lockfile as committed at v1.1.2. npm audit signatures was run locally against the public registry (505 packages with verified signatures, 100 with verified attestations).

## Screenshots (if UI change)

This isn't a UI change, skip it.

## Checklist

- [x] This PR targets the `develop` branch (not `main`)
- [x] `npm run test:all` passes locally
- [x] `npm run lint` passes locally
- [x] Documentation (README / docs) is updated if user-facing behavior changes
- [x] PR title and description are written in English
